### PR TITLE
Suppress matplotlib figuires

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -47,4 +47,9 @@ jobs:
       run: |
         python -c'from scpdt import test; test()'
 
+    - name: Run testmod a scipy submodule
+      run: |
+        python -c'from scipy.linalg import _basic; from scpdt import testmod; testmod(_basic, verbose=True)'
+
+
 

--- a/scpdt/_run.py
+++ b/scpdt/_run.py
@@ -8,7 +8,7 @@ from doctest import (OPTIONFLAGS_BY_NAME, TestResults, DocTestFinder,
 from doctest import NORMALIZE_WHITESPACE, ELLIPSIS, IGNORE_EXCEPTION_DETAIL
 
 from ._checker import DTChecker, DEFAULT_NAMESPACE, DTFinder
-
+from ._util import matplotlib_make_headless
 
 def testmod(m=None, name=None, globs=None, verbose=None,
             report=True, optionflags=0, extraglobs=None,
@@ -102,8 +102,10 @@ def testmod(m=None, name=None, globs=None, verbose=None,
         flags = NORMALIZE_WHITESPACE | ELLIPSIS | IGNORE_EXCEPTION_DETAIL
         runner = DocTestRunner(verbose=verbose, checker=DTChecker(), optionflags=flags)
 
-    for test in finder.find(m, name, globs=globs, extraglobs=extraglobs):
-        runner.run(test)
+    # our modifications
+    with matplotlib_make_headless():
+        for test in finder.find(m, name, globs=globs, extraglobs=extraglobs):
+            runner.run(test)
 
     if report:
         runner.summarize()

--- a/scpdt/_util.py
+++ b/scpdt/_util.py
@@ -1,0 +1,29 @@
+"""
+Assorted utilities.
+"""
+import warnings
+from contextlib import contextmanager
+
+@contextmanager
+def matplotlib_make_headless():
+    """ Temporarily make the matplotlib backend headless; close all figures on exit.
+    """
+    try:
+        import matplotlib
+        backend = matplotlib.get_backend()
+        matplotlib.use('Agg')
+    except ImportError:
+        backend = None
+
+    try:
+        # Matplotlib issues UserWarnings on plt.show() with a headless backend,
+        # Filter them out.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Matplotlib", UserWarning)
+            yield backend
+    finally:
+        if backend:
+            import matplotlib.pyplot as plt
+            plt.close('all')
+            matplotlib.use(backend)
+


### PR DESCRIPTION
Temporarily switch the backend to Agg. 
This is ported straight from refguide-check. The switch currently lives in `testmod`, which seems to make sense: DTRunner does not need to worry about any of these.

closes gh-6

Also try running the doctest on a private scipy submodule (which is a hack, yes).