### PR TITLE
ENH: add a three-state verbosity level : 0, 1, 2 in testmod

### DIFF
--- a/scpdt/_run.py
+++ b/scpdt/_run.py
@@ -144,6 +144,11 @@ def testmod(m=None, name=None, globs=None, verbose=None,
         Control verbosity: 0 means only report failures, 1 emit object names,
         2 is the max verbosity from doctest. Default is 0.
 
+    Returns
+    -------
+    a tuple of a DocTestResult, and a dict with details of which objects were examined
+
+
     """
     # If no module was given, then use __main__.
     if m is None:
@@ -187,7 +192,7 @@ def testmod(m=None, name=None, globs=None, verbose=None,
     if report:
         runner.summarize()
 
-    return doctest.TestResults(runner.failures, runner.tries)
+    return doctest.TestResults(runner.failures, runner.tries), runner.get_history()
 
 
 

--- a/scpdt/_tests/test_testmod.py
+++ b/scpdt/_tests/test_testmod.py
@@ -22,28 +22,28 @@ def test():
 
 
 def test_module():
-    res = testmod(module, verbose=_VERBOSE)
+    res, _ = testmod(module, verbose=_VERBOSE)
     if res.failed != 0 or res.attempted == 0:
         raise RuntimeError("Test_module(DTFinder) failed)")
     return res
 
 
 def test_module_vanilla_dtfinder():
-    res = testmod(module, verbose=_VERBOSE, use_dtfinder=False)
+    res, _ = testmod(module, verbose=_VERBOSE, use_dtfinder=False)
     if res.failed != 0 or res.attempted == 0:
         raise RuntimeError("Test_module(vanilla DocTestFinder) failed)")
     return res
 
 
 def test_stopwords():
-    res = testmod(stopwords, verbose=_VERBOSE)
+    res, _ = testmod(stopwords, verbose=_VERBOSE)
     if res.failed != 0 or res.attempted == 0:
         raise RuntimeError("Test_stopwords failed.")
     return res
 
 
 def test_public_obj_discovery():
-    res = testmod(module, verbose=_VERBOSE, strategy='public')
+    res, _ = testmod(module, verbose=_VERBOSE, strategy='public')
     if res.failed != 0 or res.attempted == 0:
         raise RuntimeError("Test_public_obj failed.")
     return res

--- a/scpdt/_tests/test_testmod.py
+++ b/scpdt/_tests/test_testmod.py
@@ -1,3 +1,6 @@
+import io
+from contextlib import redirect_stderr
+
 import numpy as np
 import pytest
 import doctest
@@ -9,7 +12,7 @@ from . import (module_cases as module,
 from .._run import testmod, find_doctests
 
 
-_VERBOSE = True
+_VERBOSE = 2
 
 
 def test():
@@ -66,7 +69,7 @@ def test_global_state():
     # Make sure doctesting does not alter the global state, as much as reasonable
     objs = [module.manip_printoptions]
     opts = np.get_printoptions()
-    testmod(module, verbose=False)
+    testmod(module)
     new_opts = np.get_printoptions()
     assert new_opts == opts
 
@@ -75,3 +78,9 @@ def test_module_debugrunner():
     with pytest.raises((doctest.UnexpectedException, doctest.DocTestFailure)):
         res = testmod(failure_cases, raise_on_error=True)
 
+
+def test_verbosity_1():
+    # smoke test that verbose=1 works
+    stream = io.StringIO()
+    with redirect_stderr(stream):
+        testmod(failure_cases, verbose=1, report=False)


### PR DESCRIPTION
cross-ref gh-14

Emitting dots or F does not seem to play very nice with the doctest structure --- it requires to have two separate streams, one to capture the doctest reports, and the other for for '...F....'. It feels like it's going to evolve into an inferior homemade pytest clone, so pass on it for now and only use three levels: 0 is failures only; 1 is emit object names just before doctesting; 2 is full, emit all examples.

Let's see how this fares on larger workloads (scipy then numpy).

Note that it's a job for a testmod-like wrapper, because DTRunner's `report_*` hooks work per-example, not per-docstring.



