### PR TITLE
BUG: handle missing __name__s in finder(..., strategy='public')

### DIFF
--- a/scpdt/_run.py
+++ b/scpdt/_run.py
@@ -39,22 +39,23 @@ def find_doctests(module, strategy=None,
         return tests
 
     if strategy == "public":
-        items, failures = get_public_objects(module)
+        (items, names), failures = get_public_objects(module)
         # XXX: handle failures
     else:
         # strategy must then be a list of objects to look at
         if not isinstance(strategy, list):
             raise ValueError(f"Expected a list of objects, got {strategy}.")
         items = strategy[:]
+        names = [item.__name__ for item in items]
 
     tests = []
-    for item in items:
+    for item, name in zip(items, names):
         if inspect.ismodule(item):
             # do not recurse, only inspect the module docstring
             _finder = DTFinder(recurse=False)
-            t = _finder.find(item, globs=globs, extraglobs=extraglobs)
+            t = _finder.find(item, name, globs=globs, extraglobs=extraglobs)
         else:
-            t = finder.find(item, globs=globs, extraglobs=extraglobs)  # FIXME: name
+            t = finder.find(item, name, globs=globs, extraglobs=extraglobs)
         tests += t
     
     return tests

--- a/scpdt/_tests/test_finder.py
+++ b/scpdt/_tests/test_finder.py
@@ -19,17 +19,18 @@ def test_get_all_list_no_all():
 
 
 def test_get_objects():
-    items, failures = get_public_objects(finder_cases)
+    (items, names), failures = get_public_objects(finder_cases)
     assert items == [finder_cases.func, finder_cases.Klass]
+    assert names == [obj.__name__ for obj in items]
     assert failures == []
 
 
-def test_get_objects_extra_itetms():
+def test_get_objects_extra_items():
     # test get_all_list on a module which defines an incorrect all.
     # Patch __all__, test, reload on exit to not depend on the test order.
     try:
         finder_cases.__all__ += ['spurious']
-        items, failures = get_public_objects(finder_cases)
+        (items, names), failures = get_public_objects(finder_cases)
 
         assert items == [finder_cases.func, finder_cases.Klass]
         assert len(failures) == 1
@@ -45,7 +46,7 @@ def test_get_objects_extra_itetms():
 
 def test_get_objects_skiplist():
     skips = [finder_cases.__name__ + '.' + 'func']
-    items, failures = get_public_objects(finder_cases, skiplist=skips)
+    (items, name), failures = get_public_objects(finder_cases, skiplist=skips)
 
     assert items == [finder_cases.Klass]
     assert failures == []

--- a/scpdt/_util.py
+++ b/scpdt/_util.py
@@ -102,13 +102,32 @@ def get_all_list(module):
 
 def get_public_objects(module, skiplist=None):
     """Return a list of public objects in a module.
+
+    Parameters
+    ----------
+    module :
+        A module look for objects
+    skiplist : list
+        The list of names to skip
+
+    Returns
+    -------
+    (items, names) : a tuple of two lists
+        `items` is a list of public objects in the module
+        `names` is a list of names of these objects. Each entry of this list
+        is nothing but `item.__name__` *if the latter exists* :
+        `name == item.__name__ if item.__name__`.
+        Otherwise, the name is taken from the `__all__` list of the module.
+    failures : list
+        a list of names which failed to be found in the module
+
     """
     if skiplist is None:
         skiplist = set()
 
     all_list, _, _ = get_all_list(module)
 
-    items, failures = [], []
+    items, names, failures = [], [], []
 
     for name in all_list:
         full_name = module.__name__ + '.' + name
@@ -119,6 +138,7 @@ def get_public_objects(module, skiplist=None):
         try:
             obj = getattr(module, name)
             items.append(obj)
+            names.append(name)
         except AttributeError:
             import traceback
             failures.append((full_name, False,
@@ -126,5 +146,5 @@ def get_public_objects(module, skiplist=None):
                             traceback.format_exc()))
             continue
 
-    return items, failures
+    return (items, names), failures
 


### PR DESCRIPTION
`finder.find(...)` tries to guess an object name if not provided. The guess is basically `obj.__name__`. This works fine most of the time, but fails for e.g. module-level constants, as those do  *not* have a `__name__` attribute.

Failures are observed in  `scipy.constants`, `scipy.stats` and `scipy.odr`.

Thus return the names explicitly.