### PR TITLE
Allow user context managers, suppress spurious NameErrors

### DIFF
--- a/scpdt/_checker.py
+++ b/scpdt/_checker.py
@@ -5,11 +5,14 @@ from doctest import NORMALIZE_WHITESPACE, ELLIPSIS, IGNORE_EXCEPTION_DETAIL
 
 import numpy as np
 
+from . import _util
 
 class DTConfig:
     """A bag class to collect various configuration bits. 
 
-    If an attribute is None, helpful defaults are subsituted.
+    If an attribute is None, helpful defaults are subsituted. If the defaults
+    are not sufficient, users should create an instance of this class,
+    override the desired attributes and pass the instance to `testmod`.
 
     Attributes
     ----------
@@ -36,6 +39,15 @@ class DTConfig:
     skiplist : set
         A list of names which are known to fail doctesting and we like to keep
         it that way e.g. sometimes pseudocode is acceptable etc.
+    user_context_mgr
+        A context manager to run tests in. Is entered for each DocTest
+        (for API docs, this is typically a single docstring). The operation is
+        roughly
+
+        >>> for test in tests:
+        ...     with user_context():
+        ...         runner.run(test)
+        Default is a noop.
 
     """
     def __init__(self, *, # DTChecker configuration
@@ -49,7 +61,9 @@ class DTConfig:
                           optionflags=None,
                           # DTFinder configuration
                           stopwords=None,
-                          skiplist=None,):
+                          skiplist=None,
+                          # Additional user configuration
+                          user_context_mgr=None):
 
         ### DTChecker configuration ###
 
@@ -116,6 +130,11 @@ class DTConfig:
                             'scipy.misc.who',  # comes from numpy
                             'scipy.optimize.show_options',])
         self.skiplist = skiplist
+
+        # User configuration
+        if user_context_mgr is None:
+            user_context_mgr = _util.noop_context_mgr
+        self.user_context_mgr = user_context_mgr
 
 
 def try_convert_namedtuple(got):

--- a/scpdt/_checker.py
+++ b/scpdt/_checker.py
@@ -275,7 +275,6 @@ class DTRunner(doctest.DocTestRunner):
     DIVIDER = "\n"
 
     def __init__(self, checker=None, verbose=None, optionflags=None, config=None):
-        self._had_unexpected_error = False
         if config is None:
             config = DTConfig()
         if checker is None:
@@ -302,13 +301,14 @@ class DTRunner(doctest.DocTestRunner):
 
     def report_unexpected_exception(self, out, test, example, exc_info):
         # Ignore name errors after failing due to an unexpected exception
-# XXX: this came in in https://github.com/scipy/scipy/pull/13116
-# Need to find out what this is about.
-#        exception_type = exc_info[0]
-#        if self._had_unexpected_error and exception_type is NameError:
-#            return
-#        self._had_unexpected_error = True
-
+        # NB: this came in in https://github.com/scipy/scipy/pull/13116
+        # However, here we attach the flag to the test itself, not the runner
+        if not hasattr(test, 'had_unexpected_error'):
+            test.had_unexpected_error = True
+        else:
+            exception_type = exc_info[0]
+            if exception_type is NameError:
+                return
         self._report_item_name(out, test.name)
         return super().report_unexpected_exception(out, test, example, exc_info)
 

--- a/scpdt/_checker.py
+++ b/scpdt/_checker.py
@@ -73,7 +73,6 @@ class DTConfig:
                           parse_namedtuples=True,  # Checker
                           nameerror_after_exception=False,  # Runner
     ):
-
         ### DTChecker configuration ###
 
         # The namespace to run examples in

--- a/scpdt/_run.py
+++ b/scpdt/_run.py
@@ -243,7 +243,8 @@ def testmod(m=None, name=None, globs=None, verbose=None,
             # after each docstring
             with np_errstate():
                 with rndm_state():
-                    runner.run(test, out=output.write)
+                    with config.user_context_mgr():
+                        runner.run(test, out=output.write)
 
     if report:
         runner.summarize()

--- a/scpdt/_tests/failure_cases_2.py
+++ b/scpdt/_tests/failure_cases_2.py
@@ -1,0 +1,24 @@
+def func_depr():
+    """
+    A test case for the user context mgr to turn warnings to errors.
+
+    >>> import warnings; warnings.warn('Sample deprecation warning', DeprecationWarning)
+    """
+
+
+def func_name_error():
+    """After an example fails, next examples may emit NameErrors. Suppress them.
+
+    Note that the suppresion is in effect for the duration of the DocTest, i.e.
+    for the whole docstring. Maybe this can be fixed at some point.
+
+    >>> def func():
+    ...     raise ValueError("oops")
+    ...     return 42
+    >>> res = func()
+    >>> res
+    >>> raise NameError('This is legitimate, but is suppressed')
+
+    Further name errors are also suppressed (which is a bug, too):
+    >>> raise NameError('Also legit')
+    """

--- a/scpdt/_tests/failure_cases_2.py
+++ b/scpdt/_tests/failure_cases_2.py
@@ -22,3 +22,4 @@ def func_name_error():
     Further name errors are also suppressed (which is a bug, too):
     >>> raise NameError('Also legit')
     """
+

--- a/scpdt/_tests/test_testmod.py
+++ b/scpdt/_tests/test_testmod.py
@@ -8,8 +8,10 @@ import doctest
 from . import (module_cases as module,
                stopwords_cases as stopwords,
                finder_cases,
-               failure_cases)
+               failure_cases,
+               failure_cases_2)
 from .._run import testmod, find_doctests
+from .._util import warnings_errors
 from .._checker import DTConfig
 
 _VERBOSE = 2
@@ -127,5 +129,4 @@ class TestNameErrorAfterException:
 
         assert "ValueError:" in output   # the original exception
         assert "NameError:"  in output   # the follow-up NameError
-
 

--- a/scpdt/_tests/test_testmod.py
+++ b/scpdt/_tests/test_testmod.py
@@ -98,18 +98,34 @@ def test_user_context():
                 config=config)
 
 
-def test_name_error_after_exception():
-    # After an example fails, subsequent examples may emit NameErrors.
-    # Check that they are suppressed.
-    # This first came in in https://github.com/scipy/scipy/pull/13116
-    stream = io.StringIO()
-    with redirect_stderr(stream):
-        testmod(failure_cases_2,
-                strategy=[failure_cases_2.func_name_error])
+class TestNameErrorAfterException:
+    def test_name_error_after_exception(self):
+        # After an example fails, subsequent examples may emit NameErrors.
+        # Check that they are suppressed.
+        # This first came in in https://github.com/scipy/scipy/pull/13116
+        stream = io.StringIO()
+        with redirect_stderr(stream):
+            testmod(failure_cases_2,
+                    strategy=[failure_cases_2.func_name_error])
 
-    stream.seek(0)
-    output = stream.read()
+        stream.seek(0)
+        output = stream.read()
 
-    assert "ValueError:" in output   # the original exception
-    assert "NameError:" not in output  # the follow-up NameError
+        assert "ValueError:" in output   # the original exception
+        assert "NameError:" not in output  # the follow-up NameError
+
+    def test_name_error_after_exception_off(self):
+        # show NameErrors
+        config = DTConfig(nameerror_after_exception=True)
+        stream = io.StringIO()
+        with redirect_stderr(stream):
+            testmod(failure_cases_2,
+                    strategy=[failure_cases_2.func_name_error], config=config)
+
+        stream.seek(0)
+        output = stream.read()
+
+        assert "ValueError:" in output   # the original exception
+        assert "NameError:"  in output   # the follow-up NameError
+
 

--- a/scpdt/_util.py
+++ b/scpdt/_util.py
@@ -74,9 +74,17 @@ def noop_context_mgr():
     """Do nothing.
 
     This is a stub context manager to serve as a default for
-    ``DTConfig().user_context_mgr``, which users can override.
+    ``DTConfig().user_context_mgr``, for users to override.
     """
     yield
+
+
+@contextmanager
+def warnings_errors():
+    """Temporarily turn all warnings to errors."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', Warning)
+        yield
 
 
 ### Object / Doctest selection helpers ###

--- a/scpdt/_util.py
+++ b/scpdt/_util.py
@@ -69,6 +69,15 @@ def np_errstate():
         with np.printoptions():
             yield
 
+@contextmanager
+def noop_context_mgr():
+    """Do nothing.
+
+    This is a stub context manager to serve as a default for
+    ``DTConfig().user_context_mgr``, which users can override.
+    """
+    yield
+
 
 ### Object / Doctest selection helpers ###
 


### PR DESCRIPTION
These patches are ported from doctest_scip_api branch, which runs `testmod` on scipy submodules.

1. Add a user-provided context manager hook to DTConfig, add a sample implementation (a noop stub, basically)
2. Suppress excessive name errors after an unexpected exception.

Details are in the commit messages. <s>Maybe</s> 2. should grow an entry in DTConfig. --- done