### PR TITLE
add DTParser and a stub testfile

### DIFF
--- a/scpdt/__init__.py
+++ b/scpdt/__init__.py
@@ -7,6 +7,6 @@ Whitespace-insensitive, numpy-aware, floating-point-aware doctest helpers.
 
 __version__ = "0.1"
 
-from ._impl import DTChecker, DTFinder, DTRunner, DebugDTRunner, DTConfig
+from ._impl import DTChecker, DTFinder, DTParser, DTRunner, DebugDTRunner, DTConfig
 from ._frontend import testmod, find_doctests, run_docstring_examples
 

--- a/scpdt/_frontend.py
+++ b/scpdt/_frontend.py
@@ -262,7 +262,7 @@ def testfile(filename, module_relative=True, name=None, package=None,
     ## XXX also extraglobs, package etc
 
     if parser is None:
-        parser = DTParser()
+        parser = DTParser(config)
 
     ### mimic `doctest.tesfile` initial set-ups
     # If no name was given, then use the file's name.

--- a/scpdt/_impl.py
+++ b/scpdt/_impl.py
@@ -359,19 +359,18 @@ class DebugDTRunner(DTRunner):
 class DTFinder(doctest.DocTestFinder):
     """A Finder with a stopword list.
     """
+    def __init__(self, verbose=False, parser=None, recurse=True, exclude_empty=True):
+        # FIXME: verbosity bool vs integer, like testmod
+        if parser is None:
+            parser = DTParser()  # FIXME: config
+        super().__init__(verbose, parser, recurse, exclude_empty)
+
     def find(self, obj, name=None, module=None, globs=None, extraglobs=None, config=None):
         if config is None:
             config = DTConfig()
         if globs is None:
             globs = dict(config.default_namespace)
         tests = super().find(obj, name, module, globs, extraglobs)
-
-        for test in tests:
-            for example in test.examples:
-                if any(word in example.source for word in config.stopwords):
-                    # Found a stopword. Do not check the output (but do check
-                    # that the source is valid python). 
-                    example.want += "  # _ignore\n"
         return tests
 
 

--- a/scpdt/_impl.py
+++ b/scpdt/_impl.py
@@ -357,19 +357,21 @@ class DebugDTRunner(DTRunner):
 
 
 class DTFinder(doctest.DocTestFinder):
-    """A Finder with a stopword list.
+    """A Finder with helpful defaults.
     """
-    def __init__(self, verbose=False, parser=None, recurse=True, exclude_empty=True):
-        # FIXME: verbosity bool vs integer, like testmod
-        if parser is None:
-            parser = DTParser()  # FIXME: config
-        super().__init__(verbose, parser, recurse, exclude_empty)
-
-    def find(self, obj, name=None, module=None, globs=None, extraglobs=None, config=None):
+    def __init__(self, verbose=None, parser=None, recurse=True,
+                 exclude_empty=True, config=None):
         if config is None:
             config = DTConfig()
+        self.config = config
+        if parser is None:
+            parser = DTParser()
+        verbose, dtverbose = _util._map_verbosity(verbose)
+        super().__init__(dtverbose, parser, recurse, exclude_empty)
+
+    def find(self, obj, name=None, module=None, globs=None, extraglobs=None):
         if globs is None:
-            globs = dict(config.default_namespace)
+            globs = dict(self.config.default_namespace)
         tests = super().find(obj, name, module, globs, extraglobs)
         return tests
 

--- a/scpdt/_impl.py
+++ b/scpdt/_impl.py
@@ -365,7 +365,7 @@ class DTFinder(doctest.DocTestFinder):
             config = DTConfig()
         self.config = config
         if parser is None:
-            parser = DTParser()
+            parser = DTParser(config)
         verbose, dtverbose = _util._map_verbosity(verbose)
         super().__init__(dtverbose, parser, recurse, exclude_empty)
 
@@ -379,10 +379,14 @@ class DTFinder(doctest.DocTestFinder):
 class DTParser(doctest.DocTestParser):
     """A Parser with a stopword list.
     """
-    def get_examples(self, string, name='<string>', config=None):
+    def __init__(self, config=None):
         if config is None:
             config = DTConfig()
-        stopwords = config.stopwords
+        self.config = config
+        # DocTestParser has no __init__, do not try calling it
+
+    def get_examples(self, string, name='<string>'):
+        stopwords = self.config.stopwords
 
         examples = []
         for example in self.parse(string, name):

--- a/scpdt/_tests/__init__.py
+++ b/scpdt/_tests/__init__.py
@@ -1,2 +1,0 @@
-from .test_testmod import test
-

--- a/scpdt/_tests/test_finder.py
+++ b/scpdt/_tests/test_finder.py
@@ -1,5 +1,6 @@
 from . import finder_cases
 from .._util import get_all_list, get_public_objects
+from .._impl import DTFinder, DTConfig
 
 def test_get_all_list():
     items, depr, other = get_all_list(finder_cases)
@@ -51,3 +52,8 @@ def test_get_objects_skiplist():
     assert items == [finder_cases.Klass]
     assert failures == []
 
+
+def test_dtfinder_config():
+    config = DTConfig()
+    finder = DTFinder(config=config)
+    assert finder.config is config

--- a/scpdt/_tests/test_parser.py
+++ b/scpdt/_tests/test_parser.py
@@ -1,4 +1,7 @@
-from .._impl import DTConfig, DTParser
+import doctest
+import pytest
+
+from .._impl import DTConfig, DTParser, DebugDTRunner
 
 def test_parser_default_config():
     # Test that parser adds the _ignore marker for stopwords
@@ -10,7 +13,6 @@ def test_parser_default_config():
     assert len(examples) == 1
     assert examples[0].source == "1 + plt.xlim([1, 2])\n"
     assert examples[0].want == "  # _ignore\n"
-
 
 def test_parser_vanilla_config():
     # Test that no stopwords means no markers
@@ -30,3 +32,30 @@ def test_config_nocopy():
     config = DTConfig()
     parser = DTParser(config)
     assert parser.config is config
+
+
+def test_stopwords_invalid_python():
+    # check that with ignore markers examples are still checked to be valid
+    # python. This string raises
+    # TypeError("unsupported operand type(s) for +: 'int' and 'tuple'")
+
+    string = ">>> import matplotlib.pyplot as plt; 1 + plt.xlim([1, 2])\n"
+
+    config = DTConfig()
+    parser = DTParser(config)
+
+    test = parser.get_doctest(string,
+                               globs=config.default_namespace,
+                               name='none',
+                               filename='none',
+                               lineno=0)
+    runner = DebugDTRunner()
+    with pytest.raises(doctest.UnexpectedException) as exc_info:
+        runner.run(test)
+
+    orig_error = exc_info.value.exc_info  # unwrap pytest -> doctest -> example
+    kind, value, traceback = orig_error
+
+    assert kind is TypeError
+    assert "unsupported operand type(s)" in value.args[0]
+

--- a/scpdt/_tests/test_parser.py
+++ b/scpdt/_tests/test_parser.py
@@ -1,0 +1,27 @@
+from .._impl import DTConfig, DTParser
+
+def test_parser_default_config():
+    # Test that parser adds the _ignore marker for stopwords
+    config = DTConfig()
+    parser = DTParser()
+
+    string = "Text text \n >>> 1 + plt.xlim([1, 2])\n\n More text"
+    examples = parser.get_examples(string, config=config)
+
+    assert len(examples) == 1
+    assert examples[0].source == "1 + plt.xlim([1, 2])\n"
+    assert examples[0].want == "  # _ignore\n"
+
+
+def test_parser_vanilla_config():
+    # Test that no stopwords means no markers
+    config = DTConfig()
+    config.stopwords = set()
+    parser = DTParser()
+
+    string = "Text text \n >>> 1 + plt.xlim([1, 2])\n\n More text"
+    examples = parser.get_examples(string, config=config)
+
+    assert len(examples) == 1
+    assert examples[0].source == "1 + plt.xlim([1, 2])\n"
+    assert examples[0].want == ""

--- a/scpdt/_tests/test_parser.py
+++ b/scpdt/_tests/test_parser.py
@@ -2,11 +2,10 @@ from .._impl import DTConfig, DTParser
 
 def test_parser_default_config():
     # Test that parser adds the _ignore marker for stopwords
-    config = DTConfig()
     parser = DTParser()
 
     string = "Text text \n >>> 1 + plt.xlim([1, 2])\n\n More text"
-    examples = parser.get_examples(string, config=config)
+    examples = parser.get_examples(string)
 
     assert len(examples) == 1
     assert examples[0].source == "1 + plt.xlim([1, 2])\n"
@@ -17,11 +16,17 @@ def test_parser_vanilla_config():
     # Test that no stopwords means no markers
     config = DTConfig()
     config.stopwords = set()
-    parser = DTParser()
+    parser = DTParser(config)
 
     string = "Text text \n >>> 1 + plt.xlim([1, 2])\n\n More text"
-    examples = parser.get_examples(string, config=config)
+    examples = parser.get_examples(string)
 
     assert len(examples) == 1
     assert examples[0].source == "1 + plt.xlim([1, 2])\n"
     assert examples[0].want == ""
+
+
+def test_config_nocopy():
+    config = DTConfig()
+    parser = DTParser(config)
+    assert parser.config is config

--- a/scpdt/_tests/test_runner.py
+++ b/scpdt/_tests/test_runner.py
@@ -47,37 +47,35 @@ def test_get_history():
     assert len(dct) == 6
 
 
-### Test the DebugDTRunner ####
+class TestDebugDTRunner:
+    def test_debug_runner_failure(self):
+        finder = DTFinder()
+        tests = finder.find(module.func9)
+        runner = DebugDTRunner(verbose=False)
 
-def test_debug_runner_failure():
-    finder = DTFinder()
-    tests = finder.find(module.func9)
-    runner = DebugDTRunner(verbose=False)
+        with pytest.raises(doctest.DocTestFailure) as exc:
+            for t in tests:
+                runner.run(t)
 
-    with pytest.raises(doctest.DocTestFailure) as exc:
-        for t in tests:
-            runner.run(t)
+        # pytest wraps the original exception, unwrap it
+        orig_exception = exc.value
 
-    # pytest wraps the original exception, unwrap it
-    orig_exception = exc.value
+        # DocTestFailure carries the doctest and the run result
+        assert orig_exception.test is tests[0]
+        assert orig_exception.test.name == 'func9'
+        assert orig_exception.got == 'array([1, 2, 3])\n'
+        assert orig_exception.example.want == 'array([2, 3, 4])\n'
 
-    # DocTestFailure carries the doctest and the run result
-    assert orig_exception.test is tests[0]
-    assert orig_exception.test.name == 'func9'
-    assert orig_exception.got == 'array([1, 2, 3])\n'
-    assert orig_exception.example.want == 'array([2, 3, 4])\n'
+    def test_debug_runner_exception(self):
+        finder = DTFinder()
+        tests = finder.find(module.func10)
+        runner = DebugDTRunner(verbose=False)
 
+        with pytest.raises(doctest.UnexpectedException) as exc:
+            for t in tests:
+                runner.run(t)
+        orig_exception = exc.value
 
-def test_debug_runner_exception():
-    finder = DTFinder()
-    tests = finder.find(module.func10)
-    runner = DebugDTRunner(verbose=False)
+        # exception carries the original test
+        assert orig_exception.test is tests[0]
 
-    with pytest.raises(doctest.UnexpectedException) as exc:
-        for t in tests:
-            runner.run(t)
-    orig_exception = exc.value
-
-    # exception carries the original test
-    assert orig_exception.test is tests[0]
-    

--- a/scpdt/_tests/test_testfile.py
+++ b/scpdt/_tests/test_testfile.py
@@ -1,0 +1,12 @@
+from .._frontend import testfile as doctestfile
+from .._impl import DTConfig
+
+def test_one_scipy_tutorial():
+    # FIXME: HACK, will not work if scipy is not installed, 
+    path = '/home/br/repos/scipy/scipy/doc/source/tutorial/ndimage.rst'
+
+    config = DTConfig()
+    config.stopwords = {}
+
+    doctestfile(path, module_relative=False, verbose=2, raise_on_error=False, config=config)
+

--- a/scpdt/_tests/test_testfile.py
+++ b/scpdt/_tests/test_testfile.py
@@ -1,6 +1,9 @@
 from .._frontend import testfile as doctestfile
 from .._impl import DTConfig
 
+import pytest
+
+@pytest.mark.xfail(True, reason="needs the scipy repo at a fixed location")
 def test_one_scipy_tutorial():
     # FIXME: HACK, will not work if scipy is not installed, 
     path = '/home/br/repos/scipy/scipy/doc/source/tutorial/ndimage.rst'

--- a/scpdt/_tests/test_testmod.py
+++ b/scpdt/_tests/test_testmod.py
@@ -17,12 +17,6 @@ from .._impl import DTConfig
 _VERBOSE = 2
 
 
-def test():
-    test_module()
-    test_module_vanilla_dtfinder()
-    test_stopwords()
-
-
 def test_module():
     res, _ = testmod(module, verbose=_VERBOSE)
     if res.failed != 0 or res.attempted == 0:

--- a/scpdt/_util.py
+++ b/scpdt/_util.py
@@ -3,6 +3,7 @@ Assorted utilities.
 """
 import os
 import warnings
+import operator
 import shutil
 import copy
 import tempfile
@@ -85,6 +86,35 @@ def warnings_errors():
     with warnings.catch_warnings():
         warnings.simplefilter('error', Warning)
         yield
+
+
+def _map_verbosity(level):
+    """A helper for validating/constructing the verbosity level.
+
+    Validate that $ 0 <= level <= 2 $ and map the boolean flag for the
+    `doctest.DocTestFinder` et al:
+    0, 1 -> False, 2 -> True
+    See the `testmod` docstring for details.
+
+
+    Parameters
+    ----------
+    level : int or None
+        Allowed values are 0, 1 or 2. None mean 0.
+
+    Returns
+    -------
+    level : int
+    dtverbose : bool
+
+    """
+    if level is None:
+        level = 0
+    level = operator.index(level)
+    if level not in [0, 1, 2]:
+        raise ValueError("Unknown verbosity setting : level = %s " % level)
+    dtverbose = True if level == 2 else False
+    return level, dtverbose
 
 
 ### Object / Doctest selection helpers ###


### PR DESCRIPTION
Add a basic `testfile` to accompany `testmod`. Since testfile does not invoke DTFinder, move the stopword list to a DTParser.

TODO for DTFinder / DTParser:

- [x] rationalize `config` handling in DTFinder : is it set in ctor or find? Add tests.
- [ ] Given that test_runner / DebugDTRunner fails with vanilla DocTestFinder, add tests for swapping DTParser for a vanilla DocTestParser.
- [x] add standalone tests for DTParser itself
- [x] properly handle verbosity mapping in DTFinder
- [x] move config handling in DTParser to ctor from methods

... and then can actually work on `testfile`.