### PR TITLE
ENH: filter PendingDeprecationWarnings in DTChecker want->a_want etc

### DIFF
--- a/scpdt/_impl.py
+++ b/scpdt/_impl.py
@@ -213,8 +213,13 @@ class DTChecker(doctest.OutputChecker):
         # OK then, convert strings to objects
         ns = dict(self.config.check_namespace)
         try:
-            a_want = eval(want, dict(ns))
-            a_got = eval(got, dict(ns))
+            with warnings.catch_warnings():
+                # NumPy's ragged array deprecation of np.array([1, (2, 3)]);
+                # also array abbreviations: try `np.diag(np.arange(1000))`
+                warnings.simplefilter('ignore', np.VisibleDeprecationWarning)
+
+                a_want = eval(want, dict(ns))
+                a_got = eval(got, dict(ns))
         except Exception:
             # Maybe we're printing a numpy array? This produces invalid python
             # code: `print(np.arange(3))` produces "[0 1 2]" w/o commas between

--- a/scpdt/_tests/module_cases.py
+++ b/scpdt/_tests/module_cases.py
@@ -121,3 +121,37 @@ def manip_printoptions():
 
     >>> np.set_printoptions(linewidth=146)
     """
+
+
+def array_abbreviation():
+    """
+    Numpy abbreviates arrays, check that it works.
+
+    NB: the implementation might need to change when
+    numpy finally disallows default-creating ragged arrays.
+    Currently, `...` gets interpreted as an Ellipsis,
+    thus the `a_want/a_got` variables in DTChecker are in fact
+    object arrays.
+
+    >>> np.arange(10000)
+    array([0, 1, 2, ..., 9997, 9998, 9999])
+
+    >>> np.diag(np.arange(33)) / 30
+    array([[0., 0., 0., ..., 0., 0.,0.],
+           [0., 0.03333333, 0., ..., 0., 0., 0.],
+           [0., 0., 0.06666667, ..., 0., 0., 0.],
+           ...,
+           [0., 0., 0., ..., 1., 0., 0.],
+           [0., 0., 0., ..., 0., 1.03333333, 0.],
+           [0., 0., 0., ..., 0., 0., 1.06666667]])
+
+
+    >>> np.diag(np.arange(1, 1001, dtype=float))
+    array([[1,    0,    0, ...,    0,    0,    0],
+           [0,    2,    0, ...,    0,    0,    0],
+           [0,    0,    3, ...,    0,    0,    0],
+            ...,
+           [0,    0,    0, ...,  998,    0,    0],
+           [0,    0,    0, ...,    0,  999,    0],
+           [0,    0,    0, ...,    0,    0, 1000]])
+    """


### PR DESCRIPTION
When run with warnings->errors, these trigger a failure in e.g. `scipy.sparse.linalg.lobpcg`, because:
- the abbreviation of `np.diag(np.arange(1000))` contains a `...`
- which is interpreted as an Ellipsis, hence `a_want/a_got` become object arrays + a PendingDeprecationWarning is emitted
- this warning turned to error triggers a test failure without   that much of a useful message.

The error reporting might need to be improved indeed, but that's separate. Currently, filtering out these errors is a correct thing to do as long as DTChecker does `w_want = eval(want)` etc.