### PR TITLE
ENH: allow for local files

### DIFF
--- a/scpdt/_frontend.py
+++ b/scpdt/_frontend.py
@@ -241,7 +241,7 @@ def testmod(m=None, name=None, globs=None, verbose=None,
         with np_errstate():
             with rndm_state():
                 with config.user_context_mgr(test):
-                    with mpl(), temp_cwd():
+                    with mpl(), temp_cwd(test, config.local_resources):
                         runner.run(test, out=output.write)
     if report:
         runner.summarize()
@@ -370,7 +370,7 @@ def testfile(filename, module_relative=True, name=None, package=None,
     with np_errstate():
         with rndm_state():
             with config.user_context_mgr(test):
-                with mpl(), temp_cwd():
+                with mpl(), temp_cwd(test, config.local_resources):
                     runner.run(test, out=output.write)
     if report:
         runner.summarize()

--- a/scpdt/_impl.py
+++ b/scpdt/_impl.py
@@ -51,6 +51,10 @@ class DTConfig:
         ...         runner.run(test)
         Default is a noop.
 
+    local_resources: dict
+        If a test needs some local files, list them here. The format is
+        ``{test.name : list-of-files}``
+        File paths are relative to path of ``test.filename``.
     parse_namedtuples : bool
         Whether to compare e.g. ``TTestResult(pvalue=0.9, statistic=42)``
         literally or extract the numbers and compare the tuple ``(0.9, 42)``.
@@ -76,6 +80,7 @@ class DTConfig:
                           skiplist=None,
                           # Additional user configuration
                           user_context_mgr=None,
+                          local_resources=None,
                           # Obscure switches
                           parse_namedtuples=True,  # Checker
                           nameerror_after_exception=False,  # Runner
@@ -151,6 +156,11 @@ class DTConfig:
         if user_context_mgr is None:
             user_context_mgr = _util.noop_context_mgr
         self.user_context_mgr = user_context_mgr
+
+        #### Local resources: None or dict {test: list-of-files-to-copy}
+        if local_resources is None:
+            local_resources = dict()
+        self.local_resources=local_resources
 
         #### Obscure switches, best leave intact
         self.parse_namedtuples = parse_namedtuples

--- a/scpdt/_tests/local_file_cases.py
+++ b/scpdt/_tests/local_file_cases.py
@@ -1,0 +1,8 @@
+
+def local_files():
+    """
+    A doctest that tries to read a local file
+
+    >>> with open('local_file.txt', 'r'):
+    ...     pass
+    """

--- a/scpdt/_tests/test_testmod.py
+++ b/scpdt/_tests/test_testmod.py
@@ -9,7 +9,8 @@ from . import (module_cases as module,
                stopwords_cases as stopwords,
                finder_cases,
                failure_cases,
-               failure_cases_2)
+               failure_cases_2,
+               local_file_cases)
 from .._frontend import testmod, find_doctests, run_docstring_examples
 from .._util import warnings_errors
 from .._impl import DTConfig
@@ -114,6 +115,17 @@ def test_user_context():
         testmod(failure_cases_2,
                 raise_on_error=True, strategy=[failure_cases_2.func_depr],
                 config=config)
+
+
+def test_local_files():
+    # A doctest tries to open a local file. Test that it works
+    # (internally, the file will need to be copied).
+    config = DTConfig()
+    config.local_resources={'scpdt._tests.local_file_cases.local_files':
+                            ['local_file.txt']}
+    res, _ = testmod(local_file_cases, config=config)
+    if res.failed != 0 or res.attempted == 0:
+        raise RuntimeError("Test_module::test_local_files")
 
 
 class TestNameErrorAfterException:

--- a/scpdt/_util.py
+++ b/scpdt/_util.py
@@ -36,10 +36,18 @@ def matplotlib_make_nongui():
 
 
 @contextmanager
-def temp_cwd():
-    """Switch to a temp directory, clean up when done."""
+def temp_cwd(test, local_resources):
+    """Switch to a temp directory, clean up when done.
+       Copy local files, if requested.
+    """
     cwd = os.getcwd()
     tmpdir = tempfile.mkdtemp()
+
+    if test.name in local_resources:
+        # local files requested; copy the files
+        path, _ = os.path.split(test.filename)
+        for fname in local_resources[test.name]:
+            shutil.copy(os.path.join(path, fname), tmpdir)      
     try:
         os.chdir(tmpdir)
         yield tmpdir


### PR DESCRIPTION
Doctests are run in a tempdir, so if a doctest tries to open a local file, the file is not found---unless copied manually.

Thus add an entry to DTConfig, `config.local_resources`, which is a dict where keys are `test.name`s and values
are lists of filenames to copy. The file names are relative to `test.filename`, i.e. most likely the sourcefile/module being
doctested.

closes gh-43