### PR TITLE
ENH: add rndm_state to DTConfig to make it user-configurable

### DIFF
--- a/scpdt/_frontend.py
+++ b/scpdt/_frontend.py
@@ -7,7 +7,7 @@ import doctest
 
 from ._impl import DTFinder, DTRunner, DebugDTRunner, DTParser, DTConfig
 from ._util import (matplotlib_make_nongui as mpl,
-                    temp_cwd, rndm_state, np_errstate,
+                    temp_cwd, np_errstate,
                     get_public_objects, _map_verbosity)
 
 
@@ -239,7 +239,7 @@ def testmod(m=None, name=None, globs=None, verbose=None,
         # *unless* the `mpl()` context mgr has a chance to filter them out
         # *before* they become errors in `config.user_context_mgr()`.
         with np_errstate():
-            with rndm_state():
+            with config.rndm_state():
                 with config.user_context_mgr(test):
                     with mpl(), temp_cwd(test, config.local_resources):
                         runner.run(test, out=output.write)
@@ -368,7 +368,7 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     # see testmod for discussion of these context managers
     with np_errstate():
-        with rndm_state():
+        with config.rndm_state():
             with config.user_context_mgr(test):
                 with mpl(), temp_cwd(test, config.local_resources):
                     runner.run(test, out=output.write)

--- a/scpdt/_impl.py
+++ b/scpdt/_impl.py
@@ -50,7 +50,9 @@ class DTConfig:
         ...     with user_context(test):
         ...         runner.run(test)
         Default is a noop.
-
+    rndm_state
+        A context manager to control the state of the random number generators.
+        The default is to make `np.random.seed(None)`, i.e. *not* reproducible.
     local_resources: dict
         If a test needs some local files, list them here. The format is
         ``{test.name : list-of-files}``
@@ -80,6 +82,7 @@ class DTConfig:
                           skiplist=None,
                           # Additional user configuration
                           user_context_mgr=None,
+                          rndm_state=None,
                           local_resources=None,
                           # Obscure switches
                           parse_namedtuples=True,  # Checker
@@ -156,6 +159,11 @@ class DTConfig:
         if user_context_mgr is None:
             user_context_mgr = _util.noop_context_mgr
         self.user_context_mgr = user_context_mgr
+
+        # random gen state
+        if rndm_state is None:
+            rndm_state = _util.default_rndm_state
+        self.rndm_state = rndm_state
 
         #### Local resources: None or dict {test: list-of-files-to-copy}
         if local_resources is None:

--- a/scpdt/_tests/scipy_linalg_tutorial_clone.rst
+++ b/scpdt/_tests/scipy_linalg_tutorial_clone.rst
@@ -884,7 +884,7 @@ algorithm. For example, the following code computes the zeroth-order
 Bessel function applied to a matrix.
 
     >>> from scipy import special, linalg
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(1638083107694713882823079058616272161)
     >>> A = rng.random((3, 3))
     >>> B = linalg.funm(A, lambda x: special.jv(0, x))
     >>> A

--- a/scpdt/_util.py
+++ b/scpdt/_util.py
@@ -57,7 +57,7 @@ def temp_cwd(test, local_resources):
 
 
 @contextmanager
-def rndm_state():
+def scipy_rndm_state():
     """Restore the `np.random` state when done."""
     # FIXME: this matches the refguide-check behavior, but is a tad strange:
     # makes sure that the seed the old-fashioned np.random* methods is *NOT* reproducible
@@ -68,6 +68,15 @@ def rndm_state():
     with _fixed_default_rng():
         np.random.seed(None)
         yield
+
+
+@contextmanager
+def default_rndm_state():
+    """Restore the `np.random` state when done."""
+    # Make sure that the seed the old-fashioned np.random* methods is *NOT* reproducible
+    import numpy as np
+    np.random.seed(None)
+    yield
 
 
 @contextmanager


### PR DESCRIPTION
Also provide a default and a current scipy version, both in _util.

closes gh-27