### PR TITLE
Test/fix/improve the skiplist handling

### DIFF
--- a/scpdt/_frontend.py
+++ b/scpdt/_frontend.py
@@ -96,6 +96,9 @@ def find_doctests(module, strategy=None,
             t = finder.find(item, full_name, globs=globs, extraglobs=extraglobs)
         tests += t
 
+    # If the skiplist contains methods of objects, their doctests may have been
+    # left in the `tests` list. Remove them.
+    tests = [t for t in tests if t.name not in config.skiplist]
     return tests
 
 

--- a/scpdt/_frontend.py
+++ b/scpdt/_frontend.py
@@ -66,6 +66,7 @@ def find_doctests(module, strategy=None,
 
     if strategy is None:
         tests = finder.find(module, name, globs=globs, extraglobs=extraglobs)
+        tests = [t for t in tests if t.name not in config.skiplist]
         return tests
 
     if strategy == "api":
@@ -83,6 +84,7 @@ def find_doctests(module, strategy=None,
         items = strategy[:]
         names = [item.__name__ for item in items]
 
+    # Having collected the list of objects, extract doctests
     tests = []
     for item, name in zip(items, names):
         full_name = module.__name__ + '.' + name

--- a/scpdt/_tests/finder_cases.py
+++ b/scpdt/_tests/finder_cases.py
@@ -36,6 +36,15 @@ class Klass:
         >>> 2 + 11
         13
         """
+        pass
+
+    def meth_2(self):
+        """
+        One other method.
+
+        >>> 111 + 1
+        112
+        """
 
 
 def private_func():

--- a/scpdt/_tests/test_finder.py
+++ b/scpdt/_tests/test_finder.py
@@ -69,6 +69,37 @@ def test_get_objects_skiplist():
     assert failures == []
 
 
+def test_explicit_object_list():
+    objs = [finder_cases.Klass]
+    tests = find_doctests(finder_cases, strategy=objs)
+
+    base = 'scpdt._tests.finder_cases'
+    assert ([test.name for test in tests] ==
+            [base + '.Klass', base + '.Klass.meth'])
+
+
+def test_explicit_object_list_with_module():
+    # Module docstrings are examined literally, without looking into other objects
+    # in the module. These other objects need to be listed explicitly.
+    # In the `doctest`-speak: do not recurse.
+    objs = [finder_cases, finder_cases.Klass]
+    tests = find_doctests(finder_cases, strategy=objs)
+
+    base = 'scpdt._tests.finder_cases'
+    assert ([test.name for test in tests] ==
+            [base, base + '.Klass', base + '.Klass.meth'])
+
+
+def test_find_doctests_api():
+    # Test that the module itself is included with strategy='api'
+    objs = [finder_cases, finder_cases.Klass]
+    tests = find_doctests(finder_cases, strategy='api')
+
+    base = 'scpdt._tests.finder_cases'
+    assert ([test.name for test in tests] ==
+            [base + '.func', base + '.Klass', base + '.Klass.meth', base])
+
+
 def test_dtfinder_config():
     config = DTConfig()
     finder = DTFinder(config=config)

--- a/scpdt/_tests/test_finder.py
+++ b/scpdt/_tests/test_finder.py
@@ -97,7 +97,40 @@ class TestSkiplist:
 
         assert sorted(names) == sorted(wanted_names)
 
+    def test_get_doctests_strategy_api(self):
+        # Add a skiplist: strategy='api' skips listed items 
+        base = finder_cases.__name__  
+        skips = [base + '.func', base + '.Klass.meth_2']
+        config = DTConfig(skiplist=skips)
 
+        tests = find_doctests(finder_cases, strategy='api', config=config)
+        names = [t.name for t in tests]
+
+        # note the lack of
+        #   - `func` and `Klass.meth_2`, as requested (via the skiplist)
+        #   - *private* stuff, which is not in `__all__`
+        wanted_names = ['Klass', 'Klass.meth']
+        wanted_names = [base] + [base + '.' + n for n in wanted_names]
+
+        assert sorted(names) == sorted(wanted_names)
+
+    def test_get_doctests_strategy_list(self):
+        # Add a skiplist: strategy=<list> skips listed items 
+        base = finder_cases.__name__  
+        skips = [base + '.func', base + '.Klass.meth_2']
+        config = DTConfig(skiplist=skips)
+
+        tests = find_doctests(finder_cases,
+                              strategy=[finder_cases.Klass], config=config)
+        names = [t.name for t in tests]
+
+        # note the lack of
+        #   - `Klass.meth_2`, as requested (via the skiplist)
+        #   - the 'base' module (via the strategy=<list>)
+        wanted_names = ['Klass', 'Klass.meth']
+        wanted_names = [base + '.' + n for n in wanted_names]
+
+        assert sorted(names) == sorted(wanted_names)
 
 
 def test_explicit_object_list():

--- a/scpdt/_tests/test_runner.py
+++ b/scpdt/_tests/test_runner.py
@@ -44,7 +44,7 @@ def test_get_history():
         runner.run(test)
 
     dct = runner.get_history()
-    assert len(dct) == 6
+    assert len(dct) == 7
 
 
 class TestDebugDTRunner:

--- a/scpdt/_tests/test_testmod.py
+++ b/scpdt/_tests/test_testmod.py
@@ -54,37 +54,6 @@ def test_public_obj_discovery():
     return res
 
 
-def test_explicit_object_list():
-    objs = [finder_cases.Klass]
-    tests = find_doctests(finder_cases, strategy=objs)
-
-    base = 'scpdt._tests.finder_cases'
-    assert ([test.name for test in tests] ==
-            [base + '.Klass', base + '.Klass.meth'])
-
-
-def test_explicit_object_list_with_module():
-    # Module docstrings are examined literally, without looking into other objects
-    # in the module. These other objects need to be listed explicitly.
-    # In the `doctest`-speak: do not recurse.
-    objs = [finder_cases, finder_cases.Klass]
-    tests = find_doctests(finder_cases, strategy=objs)
-
-    base = 'scpdt._tests.finder_cases'
-    assert ([test.name for test in tests] ==
-            [base, base + '.Klass', base + '.Klass.meth'])
-
-
-def test_find_doctests_api():
-    # Test that the module itself is included with strategy='api'
-    objs = [finder_cases, finder_cases.Klass]
-    tests = find_doctests(finder_cases, strategy='api')
-
-    base = 'scpdt._tests.finder_cases'
-    assert ([test.name for test in tests] ==
-            [base + '.func', base + '.Klass', base + '.Klass.meth', base])
-
-
 def test_run_docstring_examples():
     f = finder_cases.Klass
     res1 = run_docstring_examples(f)


### PR DESCRIPTION
- do not ignore the skiplist for strategy=None
- allow skipping of individual methods on objects

The latter is observed e.g. in `numpy.core.ndarray.__class_getitem__` which needs to be skipped for python < 3.9