### PR TITLE
ENH: implement the +SKIPBLOCK optionflag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,15 @@ the output. Thus the example source needs to be valid python code still.
   of these markers, it is considered pseudocode and is not checked.
   This is useful for `from example import some_functions` and similar stanzas.
 
+- A `# doctest: +SKIPBLOCK` option flag to skip whole blocks of pseudocode. Here
+  a 'block' is a sequence of doctest examples without any intervening text.
+
 - *Doctest discovery* is somewhat more flexible then the standard library
   `doctest` module. Specifically, one can use `testmod(module, strategy='api')`
   to only examine public objects of a module. This is helpful for complex
-  packages, with non-trivial internal file structure.
+  packages, with non-trivial internal file structure. Alternatively, the default
+  value of `strategy=None` is equivalent to the standard `doctest` module
+  behavior.
 
 - *User configuration*. Essentially all aspects of the behavior are user
   configurable via a `DTConfig` instance attributes. See the `DTConfig`

--- a/scpdt/_tests/test_skipmarkers.py
+++ b/scpdt/_tests/test_skipmarkers.py
@@ -153,3 +153,39 @@ class TestMayVary:
         with pytest.raises(doctest.DocTestFailure):
             runner.run(test)
 
+
+string='''\
+
+This is an example string with doctests and skipblocks. A block is a sequence
+of examples (which start with a >>> marker) without an intervening text, like
+below
+
+>>> from some_module import some_function    # doctest: +SKIPBLOCK
+>>> some_function(42)
+
+Note how the block above will fail doctesting unless the second line is
+skipped. A standard solution is to add a +SKIP marker to every line, but this
+is ugly and we skip the whole block instead. 
+
+Once the block is over, we get back to usual doctests, which are not skipped
+
+>>> 1 + 2
+3
+
+'''
+
+def test_SKIPBLOCK():
+    parser = DTParser()
+    test = parser.get_doctest(string,
+                               globs={},
+                               name='SKIPBLOCK test',
+                               filename='none',
+                               lineno=0)
+
+    SKIP = doctest.OPTIONFLAGS_BY_NAME['SKIP']
+
+    assert len(test.examples) == 3
+    assert test.examples[0].options[SKIP] is True
+    assert test.examples[1].options[SKIP] is True
+    assert test.examples[2].options == {}    # not skipped
+


### PR DESCRIPTION
cf gh-10, there is finally a need for this, in numpy rst tutorials.

The original refguide-check implementation is a hack, the idea of adding a doctest optionflag is from the numpy version of refguide-check.

Here the implementation is to add a `# doctest: +SKIP` internally to every Example in a block.