### PR TITLE
ENH: remove a separate rndm_state context manager

### DIFF
--- a/scpdt/_frontend.py
+++ b/scpdt/_frontend.py
@@ -234,9 +234,8 @@ def testmod(m=None, name=None, globs=None, verbose=None,
     for test in tests:
         if verbose == 1:
             output.write(test.name + '\n')
-        # restore (i) the errstate/print state, and (ii) np.random state
-        # after each docstring. Also make MPL backend non-GUI and close
-        # the figures.
+        # restore the errstate/print state after each docstring.
+        # Also make MPL backend non-GUI and close the figures.
         # The order of context managers is actually relevant. Consider
         # a user_context_mgr that turns warnings into errors.
         # Additionally, suppose that MPL deprecates something and plt.something
@@ -244,10 +243,9 @@ def testmod(m=None, name=None, globs=None, verbose=None,
         # *unless* the `mpl()` context mgr has a chance to filter them out
         # *before* they become errors in `config.user_context_mgr()`.
         with np_errstate():
-            with config.rndm_state():
-                with config.user_context_mgr(test):
-                    with mpl(), temp_cwd(test, config.local_resources):
-                        runner.run(test, out=output.write)
+            with config.user_context_mgr(test):
+                with mpl(), temp_cwd(test, config.local_resources):
+                    runner.run(test, out=output.write)
     if report:
         runner.summarize()
     return doctest.TestResults(runner.failures, runner.tries), runner.get_history()
@@ -377,10 +375,9 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     # see testmod for discussion of these context managers
     with np_errstate():
-        with config.rndm_state():
-            with config.user_context_mgr(test):
-                with mpl(), temp_cwd(test, config.local_resources):
-                    runner.run(test, out=output.write)
+        with config.user_context_mgr(test):
+            with mpl(), temp_cwd(test, config.local_resources):
+                runner.run(test, out=output.write)
     if report:
         runner.summarize()
     return doctest.TestResults(runner.failures, runner.tries), runner.get_history()

--- a/scpdt/_impl.py
+++ b/scpdt/_impl.py
@@ -54,9 +54,6 @@ class DTConfig:
         ...     with user_context(test):
         ...         runner.run(test)
         Default is a noop.
-    rndm_state
-        A context manager to control the state of the random number generators.
-        The default is to make `np.random.seed(None)`, i.e. *not* reproducible.
     local_resources: dict
         If a test needs some local files, list them here. The format is
         ``{test.name : list-of-files}``
@@ -86,7 +83,6 @@ class DTConfig:
                           skiplist=None,
                           # Additional user configuration
                           user_context_mgr=None,
-                          rndm_state=None,
                           local_resources=None,
                           # Obscure switches
                           parse_namedtuples=True,  # Checker
@@ -163,11 +159,6 @@ class DTConfig:
         if user_context_mgr is None:
             user_context_mgr = _util.noop_context_mgr
         self.user_context_mgr = user_context_mgr
-
-        # random gen state
-        if rndm_state is None:
-            rndm_state = _util.default_rndm_state
-        self.rndm_state = rndm_state
 
         #### Local resources: None or dict {test: list-of-files-to-copy}
         if local_resources is None:

--- a/scpdt/_util.py
+++ b/scpdt/_util.py
@@ -67,6 +67,9 @@ def temp_cwd(test, local_resources=None):
         shutil.rmtree(tmpdir)
 
 
+# Options for the usr_context_mgr : do nothing (default), and control the random
+# state, in two flavors.
+
 @contextmanager
 def scipy_rndm_state():
     """Restore the `np.random` state when done."""
@@ -82,21 +85,12 @@ def scipy_rndm_state():
 
 
 @contextmanager
-def default_rndm_state():
+def numpy_rndm_state():
     """Restore the `np.random` state when done."""
     # Make sure that the seed the old-fashioned np.random* methods is *NOT* reproducible
     import numpy as np
     np.random.seed(None)
     yield
-
-
-@contextmanager
-def np_errstate():
-    """A context manager to restore the numpy errstate and printoptions when done."""
-    import numpy as np
-    with np.errstate():
-        with np.printoptions():
-            yield
 
 
 @contextmanager
@@ -107,6 +101,15 @@ def noop_context_mgr(test):
     ``DTConfig().user_context_mgr``, for users to override.
     """
     yield
+
+
+@contextmanager
+def np_errstate():
+    """A context manager to restore the numpy errstate and printoptions when done."""
+    import numpy as np
+    with np.errstate():
+        with np.printoptions():
+            yield
 
 
 @contextmanager


### PR DESCRIPTION
Controlling the rng behavior is on the user, in the user_context_mgr.

closes gh-54