### PR TITLE
ENH: Configure pytest to use DTChecker

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -65,4 +65,4 @@ jobs:
 
     - name: Test pytest plugin
       run: |
-        python -m pytest --doctest-modules
+        python -m pytest

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -65,4 +65,4 @@ jobs:
 
     - name: Test pytest plugin
       run: |
-        python -m pytest
+        python -m pytest scpdt/tests/module_cases.py --doctest-modules

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -62,3 +62,7 @@ jobs:
     - name: Run testmod a scipy submodule -- Public API onlly
       run: |
         python -c'from scipy import linalg; from scpdt import testmod; testmod(linalg, verbose=True, strategy="api")'
+
+    - name: Test pytest plugin
+      run: |
+        python -m pytest --doctest-modules

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -64,5 +64,6 @@ jobs:
         python -c'from scipy import linalg; from scpdt import testmod; testmod(linalg, verbose=True, strategy="api")'
 
     - name: Test pytest plugin
+      # This test will fail in a venv where scpdt has not been installed and the plugin has not been activated
       run: |
         python -m pytest scpdt/tests/module_cases.py --doctest-modules

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ __pycache__
 
 lib/
 bin/
-
+venv/
 .pytest_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies  = [
     "pytest",
 ]
 
-[project.optional-dependenices]
+[project.optional-dependencies]
 test = [
     "scipy",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,40 @@
 [build-system]
-requires = ["flit_core >=3.2,<4",
-            "numpy"
-]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
 name = "scpdt"
-authors = [{name = "Evgeni Burovski et al", email = "evgeny.burovskiy@gmail.com"}]
+authors = [
+    {name = "Evgeni Burovski et al", email = "evgeny.burovskiy@gmail.com"}
+    ]
 readme = "README.md"
+requires-python = ">=3.8"
+license={file = "LICENSE"}
 dynamic = ["version", "description"]
 classifiers = [
-    "License :: OSI Approved :: BSD License",
-    "Private :: Do Not Upload"
+    "Private :: Do Not Upload",
+    "Programming Language :: Python :: 3",
+    "Framework :: Pytest"
+]
+dependencies  = [
+    "numpy>=1.19.5",
+    "pytest",
 ]
 
-requires  = [
-    "numpy>=1.19.5"
+[project.optional-dependenices]
+test = [
+    "scipy",
+    "matplotlib",
+    "pytest"
 ]
 
 [project.urls]
 Home = "https://github.com/ev-br/scpdt"
+
+[tool.pytest.ini_options]
+addopts = "--verbose --color=yes"
+
+# specify project entrypoints to make each plugin discoverable by pytest
+# ref: https://docs.pytest.org/en/latest/how-to/writing_plugins.html#making-your-plugin-installable-by-others
+[project.entry-points.pytest11]
+scpdt = "scpdt.plugin"

--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -91,7 +91,7 @@ class DTConfig:
         ### DTChecker configuration ###
         # The namespace to run examples in
         if default_namespace is None:
-            default_namespace = {'np': np}
+            default_namespace = {}
         self.default_namespace = default_namespace
 
         # The namespace to do checks in
@@ -200,6 +200,7 @@ class DTChecker(doctest.OutputChecker):
         self.rndm_markers.add('# _ignore')  # technical, private. See DTParser
 
     def check_output(self, want, got, optionflags):
+
         # cut it short if they are equal
         if want == got:
             return True

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -1,7 +1,7 @@
 """
 A pytest plugin that provides enhanced doctesting for Pydata libraries
 """
-import numpy as np
+
 from _pytest import doctest
 
 from scpdt.impl import DTChecker, DTConfig
@@ -18,6 +18,6 @@ def pytest_configure(config):
 
 def _get_checker():
     """
-    Override function to return the DTChecker
+    Override function to return an instance of DTChecker with default configurations
     """
-    return DTChecker(config=DTConfig(default_namespace={'np': np}))
+    return DTChecker(config=DTConfig())

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -21,4 +21,4 @@ def _get_checker():
     """
     Override function to return the DTChecker
     """
-    return DTChecker()
+    return DTChecker(config=DTConfig())

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -1,8 +1,7 @@
 """
 A pytest plugin that provides enhanced doctesting for Pydata libraries
 """
-
-# import doctest
+import numpy as np
 from _pytest import doctest
 
 from scpdt.impl import DTChecker, DTConfig
@@ -21,4 +20,4 @@ def _get_checker():
     """
     Override function to return the DTChecker
     """
-    return DTChecker(config=DTConfig())
+    return DTChecker(config=DTConfig(default_namespace={'np': np}))

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -7,16 +7,6 @@ from _pytest import doctest
 
 from scpdt.impl import DTChecker, DTConfig
 
-def pytest_addoption(parser):
-    """
-    Register argparse-style options and ini-style config values,
-    called once at the beginning of a test run.
-    """
-    parser.addoption(
-        "--doctest-scpt", 
-        action="store_true",
-        help="Enable doctesting for pydata libraries."
-        )
 
 def pytest_configure(config):
     """
@@ -24,10 +14,6 @@ def pytest_configure(config):
     """
     if config.pluginmanager.getplugin('doctest'):
         config.pluginmanager.register(DTChecker())
-
-    use_scpdt = config.getoption("doctest_scpdt")
-    if not use_scpdt:
-        return
 
     doctest._get_checker = _get_checker
 

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -1,0 +1,38 @@
+"""
+A pytest plugin that provides enhanced doctesting for Pydata libraries
+"""
+
+# import doctest
+from _pytest import doctest
+
+from scpdt.impl import DTChecker, DTConfig
+
+def pytest_addoption(parser):
+    """
+    Register argparse-style options and ini-style config values,
+    called once at the beginning of a test run.
+    """
+    parser.addoption(
+        "--doctest-scpt", 
+        action="store_true",
+        help="Enable doctesting for pydata libraries."
+        )
+
+def pytest_configure(config):
+    """
+    Allow plugins and conftest files to perform initial configuration.
+    """
+    if config.pluginmanager.getplugin('doctest'):
+        config.pluginmanager.register(DTChecker())
+
+    use_scpdt = config.getoption("doctest_scpdt")
+    if not use_scpdt:
+        return
+
+    doctest._get_checker = _get_checker
+
+def _get_checker():
+    """
+    Override function to return the DTChecker
+    """
+    return DTChecker()

--- a/scpdt/tests/failure_cases.py
+++ b/scpdt/tests/failure_cases.py
@@ -2,7 +2,7 @@
 def func9():
     """
     Wrong output.
-
+    >>> import numpy as np
     >>> np.array([1, 2, 3])
     array([2, 3, 4])
     """
@@ -11,6 +11,6 @@ def func9():
 def func10():
     """
     NameError
-
+    >>> import numpy as np
     >>> np.arraY([1, 2, 3])
     """

--- a/scpdt/tests/module_cases.py
+++ b/scpdt/tests/module_cases.py
@@ -10,6 +10,7 @@ def func2():
     """
     Check that `np.` is imported and the array repr is recognized. Also check
     that whitespace is irrelevant for the checker.
+    >>> import numpy as np
     >>> np.array([1,         2,          3.0])
     array([1, 2, 3])
 
@@ -28,6 +29,7 @@ def func2():
 def func3():
     """
     Check that printed arrays are checked with atol/rtol
+    >>> import numpy as np
     >>> a = np.array([1, 2, 3, 4]) / 3
     >>> print(a)
     [0.33  0.66  1  1.33]
@@ -38,7 +40,7 @@ def func4():
     """
     Test `# may vary` markers : these should not break doctests (but the code
     should still be valid, otherwise it's an error).
-
+    >>> import numpy as np
     >>> np.random.randint(50)
     42      # may vary
 
@@ -53,7 +55,7 @@ def func4():
 def func5():
     """
     Object addresses are ignored:
-
+    >>> import numpy as np
     >>> np.array([1, 2, 3]).data
     <memory at 0x7f119b952400>
     """
@@ -103,6 +105,7 @@ def func7():
     Multiline namedtuples + nested tuples, see scipy/gh-16082
 
     >>> from scipy import stats
+    >>> import numpy as np
     >>> a = np.arange(10)
     >>> stats.describe(a)
     DescribeResult(nobs=10, minmax=(0, 9), mean=4.5,
@@ -118,7 +121,7 @@ def func7():
 
 def manip_printoptions():
     """Manipulate np.printoptions.
-
+    >>> import numpy as np
     >>> np.set_printoptions(linewidth=146)
     """
 
@@ -132,7 +135,7 @@ def array_abbreviation():
     Currently, `...` gets interpreted as an Ellipsis,
     thus the `a_want/a_got` variables in DTChecker are in fact
     object arrays.
-
+    >>> import numpy as np
     >>> np.arange(10000)
     array([0, 1, 2, ..., 9997, 9998, 9999])
 

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -1,40 +1,25 @@
 import pytest
+from pathlib import PosixPath
+
+
+from . import module_cases, failure_cases, failure_cases_2
+
 pytest_plugins = ['pytester']
 
-
-def test_array_abbreviation(pytester):
-    """
-    Test that pytest uses the DTChecker that handles array abbreviation
-    """
-
-    file_content = """
-    def array_abbreviation():
-        '''
-        >>> import numpy as np
-        >>> np.arange(10000)
-        array([0, 1, 2, ..., 9997, 9998, 9999])
-
-        >>> np.diag(np.arange(33)) / 30
-        array([[0., 0., 0., ..., 0., 0.,0.],
-            [0., 0.03333333, 0., ..., 0., 0., 0.],
-            [0., 0., 0.06666667, ..., 0., 0., 0.],
-            ...,
-            [0., 0., 0., ..., 1., 0., 0.],
-            [0., 0., 0., ..., 0., 1.03333333, 0.],
-            [0., 0., 0., ..., 0., 0., 1.06666667]])
-
-
-        >>> np.diag(np.arange(1, 1001, dtype=float))
-        array([[1,    0,    0, ...,    0,    0,    0],
-            [0,    2,    0, ...,    0,    0,    0],
-            [0,    0,    3, ...,    0,    0,    0],
-                ...,
-            [0,    0,    0, ...,  998,    0,    0],
-            [0,    0,    0, ...,    0,  999,    0],
-            [0,    0,    0, ...,    0,    0, 1000]])
-        '''
-        pass
-        """
-    pytester.makepyfile(file_content)
-    result = pytester.runpytest("--doctest-modules") 
+"""
+Test that pytest uses the DTChecker for doctests
+"""
+def test_module_cases(pytester):
+    path_str = module_cases.__file__
+    python_file = PosixPath(path_str)
+    result = pytester.inline_run(python_file, "--doctest-modules")
     assert result.ret == pytest.ExitCode.OK
+
+
+def test_failure_cases(pytester):
+    file_list = [failure_cases, failure_cases_2]
+    for file in file_list:
+        path_str = file.__file__
+        python_file = PosixPath(path_str)
+        result = pytester.inline_run(python_file, "--doctest-modules")
+    assert result.ret == pytest.ExitCode.TESTS_FAILED

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -10,6 +10,7 @@ def test_array_abbreviation(pytester):
     file_content = """
     def array_abbreviation():
         '''
+        >>> import numpy as np
         >>> np.arange(10000)
         array([0, 1, 2, ..., 9997, 9998, 9999])
 

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -1,6 +1,6 @@
 import pytest
-
 pytest_plugins = ['pytester']
+
 
 def test_array_abbreviation(pytester):
     """
@@ -10,7 +10,9 @@ def test_array_abbreviation(pytester):
     file_content = """
     def array_abbreviation():
         '''
-        >>> import numpy as np    
+        >>> np.arange(10000)
+        array([0, 1, 2, ..., 9997, 9998, 9999])
+
         >>> np.diag(np.arange(33)) / 30
         array([[0., 0., 0., ..., 0., 0.,0.],
             [0., 0.03333333, 0., ..., 0., 0., 0.],
@@ -19,11 +21,19 @@ def test_array_abbreviation(pytester):
             [0., 0., 0., ..., 1., 0., 0.],
             [0., 0., 0., ..., 0., 1.03333333, 0.],
             [0., 0., 0., ..., 0., 0., 1.06666667]])
+
+
+        >>> np.diag(np.arange(1, 1001, dtype=float))
+        array([[1,    0,    0, ...,    0,    0,    0],
+            [0,    2,    0, ...,    0,    0,    0],
+            [0,    0,    3, ...,    0,    0,    0],
+                ...,
+            [0,    0,    0, ...,  998,    0,    0],
+            [0,    0,    0, ...,    0,  999,    0],
+            [0,    0,    0, ...,    0,    0, 1000]])
         '''
         pass
         """
     pytester.makepyfile(file_content)
-
-    result = pytester.runpytest("--doctest-modules")
-    
+    result = pytester.runpytest("--doctest-modules") 
     assert result.ret == pytest.ExitCode.OK

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -25,6 +25,5 @@ def test_array_abbreviation(pytester):
     pytester.makepyfile(file_content)
 
     result = pytester.runpytest("--doctest-modules")
-    print(f"==================================>{result}")
     
     assert result.ret == pytest.ExitCode.OK

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -1,0 +1,30 @@
+import pytest
+
+pytest_plugins = ['pytester']
+
+def test_array_abbreviation(pytester):
+    """
+    Test that pytest uses the DTChecker that handles array abbreviation
+    """
+
+    file_content = """
+    def array_abbreviation():
+        '''
+        >>> import numpy as np    
+        >>> np.diag(np.arange(33)) / 30
+        array([[0., 0., 0., ..., 0., 0.,0.],
+            [0., 0.03333333, 0., ..., 0., 0., 0.],
+            [0., 0., 0.06666667, ..., 0., 0., 0.],
+            ...,
+            [0., 0., 0., ..., 1., 0., 0.],
+            [0., 0., 0., ..., 0., 1.03333333, 0.],
+            [0., 0., 0., ..., 0., 0., 1.06666667]])
+        '''
+        pass
+        """
+    pytester.makepyfile(file_content)
+
+    result = pytester.runpytest("--doctest-modules")
+    print(f"==================================>{result}")
+    
+    assert result.ret == pytest.ExitCode.OK


### PR DESCRIPTION
- implemented the `pytest_configure` hook to register `DTChecker` as a plugin thus allowing pytest to use it during doctest execution.
- overrode the [`_get_checker`]( https://github.com/pytest-dev/pytest/blob/7c30f674c58ee16f2b74ef85bb8765252764ef70/src/_pytest/doctest.py#L678) function to return the `DTChecker`.
- added test cases to assert that pytest utilizes the DTChecker which handles numpy's intricacies.
- changed the `default_namespace` attribute to {} for explicit import of `numpy` in test examples.
- explicitly imported `numpy` in all docstring test examples.
- added a CI test that performs doctests through the plugin.

Closes #72