### PR TITLE
Copy local files to current working directory

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Test pytest plugin
       # This test will fail in a venv where scpdt has not been installed and the plugin has not been activated
       run: |
-        test_files=("scpdt/tests/module_cases.py" "scpdt/tests/stopwords_cases.py")
+        test_files=("scpdt/tests/module_cases.py" "scpdt/tests/stopwords_cases.py" "scpdt/tests/local_file_cases.py")
           for file in "${test_files[@]}"; do
             python -m pytest "${file}" --doctest-modules
           done

--- a/scpdt/conftest.py
+++ b/scpdt/conftest.py
@@ -1,10 +1,11 @@
 from scpdt.impl import DTConfig
 
 
-config = DTConfig()
-config.local_resources = {'scpdt.tests.local_file_cases.local_files':
+dt_config = DTConfig()
+
+# Specify local files required by doctests
+dt_config.local_resources = {'scpdt.tests.local_file_cases.local_files':
                                   ['scpdt/tests/local_file.txt'],
                             'scpdt.tests.local_file_cases.sio':
                                   ['scpdt/tests/octave_a.mat']   
                                   }
-

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -47,13 +47,15 @@ def copy_local_files(local_resources, destination_dir):
     Copy necessary local files for doctests to the current working directory. 
     The files to be copied are defined by the `local_resources` attribute of a DTConfig instance.
     """
+    import pdb
+    pdb.set_trace()
     for key, value in local_resources.items():
-        path = value[0]
-        basename = os.path.basename(path)
-        filepath = os.path.join(destination_dir, basename)
-        if not os.path.exists(filepath):
-            shutil.copy(path, destination_dir)
-            copied_files.append(filepath)    
+        for i in range(0, len(value)):
+            basename = os.path.basename(value[i])
+            filepath = os.path.join(destination_dir, basename)
+            if not os.path.exists(filepath):
+                shutil.copy(value[i], destination_dir)
+                copied_files.append(filepath)    
     return copied_files
 
 

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -39,17 +39,15 @@ def _get_checker():
     return DTChecker(config=user_config)
 
 
-def copy_local_files(local_resources):
-    cwd = os.getcwd()
+def copy_local_files(local_resources, destination_dir):
     for key, value in local_resources.items():
         path = os.path.abspath(value[0])
         basename = os.path.basename(path)
-        filepath = os.path.join(cwd, basename)
-        if os.path.exists(filepath):
-            continue
-        shutil.copy(path, cwd)
-        copied_files.append(filepath)    
-    return
+        filepath = os.path.join(destination_dir, basename)
+        if not os.path.exists(filepath):
+            shutil.copy(path, destination_dir)
+            copied_files.append(filepath)    
+    return copied_files
 
 
 class DTModule(DoctestModule):
@@ -83,7 +81,7 @@ class DTModule(DoctestModule):
                 else:
                     raise
         if len(user_config.local_resources) > 0:
-            copy_local_files(user_config.local_resources)
+            copy_local_files(user_config.local_resources, os.getcwd())
         # The `_pytest.doctest` module uses the internal doctest parsing mechanism.
         # We plugin scpdt's `DTFinder` that uses the `DTParser` which parses the doctest examples 
         # from the python module or file and filters out stopwords and pseudocode.

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -41,7 +41,7 @@ def _get_checker():
 
 def copy_local_files(local_resources, destination_dir):
     for key, value in local_resources.items():
-        path = os.path.abspath(value[0])
+        path = value[0]
         basename = os.path.basename(path)
         filepath = os.path.join(destination_dir, basename)
         if not os.path.exists(filepath):

--- a/scpdt/tests/conftest.py
+++ b/scpdt/tests/conftest.py
@@ -1,8 +1,8 @@
 from scpdt.impl import DTConfig
 
 
-user_config = DTConfig()
-user_config.local_resources = {'scpdt.tests.local_file_cases.local_files':
+config = DTConfig()
+config.local_resources = {'scpdt.tests.local_file_cases.local_files':
                                   ['scpdt/tests/local_file.txt'],
                             'scpdt.tests.local_file_cases.sio':
                                   ['scpdt/tests/octave_a.mat']   

--- a/scpdt/tests/conftest.py
+++ b/scpdt/tests/conftest.py
@@ -1,8 +1,4 @@
-import pytest
 from scpdt.impl import DTConfig
-import os
-import shutil
-
 
 
 user_config = DTConfig()

--- a/scpdt/tests/conftest.py
+++ b/scpdt/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from scpdt.impl import DTConfig
+import os
+import shutil
+
+
+
+user_config = DTConfig()
+user_config.local_resources = {'scpdt.tests.local_file_cases.local_files':
+                                  ['scpdt/tests/local_file.txt'],
+                            'scpdt.tests.local_file_cases.sio':
+                                  ['scpdt/tests/octave_a.mat']   
+                                  }
+

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -18,7 +18,9 @@ def copy_files():
     """
     dirname = os.path.dirname(Path(__file__))
     for key, value in config.local_resources.items():
-        value[0] = os.path.join(dirname, os.path.basename(value[0]))
+        # Update the filepath of each filename
+        for i in range(0, len(value)):
+            value[i] = os.path.join(dirname, os.path.basename(value[i]))
     copied_files = copy_local_files(config.local_resources, os.getcwd())
     try: 
         yield copied_files

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -9,27 +9,27 @@ pytest_plugins = ['pytester']
 """
 Test that pytest uses the DTChecker for doctests
 """
-def test_module_cases(pytester):
+""" def test_module_cases(pytester):
     path_str = module_cases.__file__
     python_file = PosixPath(path_str)
     result = pytester.inline_run(python_file, "--doctest-modules")
-    assert result.ret == pytest.ExitCode.OK
+    assert result.ret == pytest.ExitCode.OK """
 
 
-def test_failure_cases(pytester):
+""" def test_failure_cases(pytester):
     file_list = [failure_cases, failure_cases_2]
     for file in file_list:
         path_str = file.__file__
         python_file = PosixPath(path_str)
         result = pytester.inline_run(python_file, "--doctest-modules")
-    assert result.ret == pytest.ExitCode.TESTS_FAILED
+    assert result.ret == pytest.ExitCode.TESTS_FAILED """
     
 
 """
 Test that pytest uses the DTParser for doctests
 """
-def test_stopword_cases(pytester):
+""" def test_stopword_cases(pytester):
     path_str = stopwords_cases.__file__
     python_file = PosixPath(path_str)
     result = pytester.inline_run(python_file, "--doctest-modules")
-    assert result.ret == pytest.ExitCode.OK
+    assert result.ret == pytest.ExitCode.OK """

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -3,17 +3,21 @@ from pathlib import PosixPath
 
 
 from . import module_cases, failure_cases, failure_cases_2, stopwords_cases
+from scpdt.plugin import copy_local_files
+from scpdt.tests.conftest import user_config
+
 
 pytest_plugins = ['pytester']
 
 """
 Test that pytest uses the DTChecker for doctests
 """
-""" def test_module_cases(pytester):
+def test_module_cases(pytester):
     path_str = module_cases.__file__
     python_file = PosixPath(path_str)
+    copy_local_files(user_config.local_resources)
     result = pytester.inline_run(python_file, "--doctest-modules")
-    assert result.ret == pytest.ExitCode.OK """
+    assert result.ret == pytest.ExitCode.OK
 
 
 """ def test_failure_cases(pytester):

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -4,17 +4,22 @@ from pathlib import PosixPath, Path
 
 from . import module_cases, failure_cases, failure_cases_2, stopwords_cases, local_file_cases
 from scpdt.plugin import copy_local_files
-from scpdt.tests.conftest import user_config
+from scpdt.tests.conftest import config
 
 pytest_plugins = ['pytester']
 
 
 @pytest.fixture(autouse=True)
 def copy_files():
+    """
+    Copy necessary local files for doctests to the temporary directory used by pytester. 
+    The files to be copied are defined by the `local_resources` attribute of a DTConfig instance.
+    When testing is done, all copied files are deleted.
+    """
     dirname = os.path.dirname(Path(__file__))
-    for key, value in user_config.local_resources.items():
+    for key, value in config.local_resources.items():
         value[0] = os.path.join(dirname, os.path.basename(value[0]))
-    copied_files = copy_local_files(user_config.local_resources, os.getcwd())
+    copied_files = copy_local_files(config.local_resources, os.getcwd())
     try: 
         yield copied_files
     finally:

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -12,34 +12,42 @@ pytest_plugins = ['pytester']
 """
 Test that pytest uses the DTChecker for doctests
 """
+
+@pytest.fixture(autouse=True)
+def copy_files():
+    dirname = os.path.dirname(os.getcwd())
+    copied_files = copy_local_files(user_config.local_resources, dirname)
+    try: 
+        yield copied_files
+    finally:
+        for filepath in copied_files:
+            try:
+                os.remove(filepath)
+            except FileNotFoundError:
+                pass
+
+
 def test_module_cases(pytester):
     path_str = module_cases.__file__
     python_file = PosixPath(path_str)
-    destination_dir = pytester.path
-    copied_files = copy_local_files(user_config.local_resources, destination_dir)
     result = pytester.inline_run(python_file, "--doctest-modules")
-    for filepath in copied_files:
-        try:
-            os.remove(filepath)
-        except FileNotFoundError:
-            pass
     assert result.ret == pytest.ExitCode.OK
 
 
-""" def test_failure_cases(pytester):
+def test_failure_cases(pytester):
     file_list = [failure_cases, failure_cases_2]
     for file in file_list:
         path_str = file.__file__
         python_file = PosixPath(path_str)
         result = pytester.inline_run(python_file, "--doctest-modules")
-    assert result.ret == pytest.ExitCode.TESTS_FAILED """
+    assert result.ret == pytest.ExitCode.TESTS_FAILED
     
 
 """
 Test that pytest uses the DTParser for doctests
 """
-""" def test_stopword_cases(pytester):
+def test_stopword_cases(pytester):
     path_str = stopwords_cases.__file__
     python_file = PosixPath(path_str)
     result = pytester.inline_run(python_file, "--doctest-modules")
-    assert result.ret == pytest.ExitCode.OK """
+    assert result.ret == pytest.ExitCode.OK

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -4,7 +4,7 @@ from pathlib import PosixPath, Path
 
 from . import module_cases, failure_cases, failure_cases_2, stopwords_cases, local_file_cases
 from scpdt.plugin import copy_local_files
-from scpdt.tests.conftest import config
+from scpdt.conftest import dt_config
 
 pytest_plugins = ['pytester']
 
@@ -16,20 +16,27 @@ def copy_files():
     The files to be copied are defined by the `local_resources` attribute of a DTConfig instance.
     When testing is done, all copied files are deleted.
     """
-    dirname = os.path.dirname(Path(__file__))
-    for key, value in config.local_resources.items():
-        # Update the filepath of each filename
-        for i in range(0, len(value)):
-            value[i] = os.path.join(dirname, os.path.basename(value[i]))
-    copied_files = copy_local_files(config.local_resources, os.getcwd())
-    try: 
+    try:
+        dirname = os.path.dirname(Path(__file__))
+
+        # Update the file path of each filename
+        for value in dt_config.local_resources.values():
+            for i, path in enumerate(value):
+                value[i] = os.path.join(dirname, os.path.basename(path))
+
+        # Copy the files
+        copied_files = copy_local_files(dt_config.local_resources, os.getcwd())
+
         yield copied_files
+
     finally:
+        # Perform clean-up
         for filepath in copied_files:
             try:
                 os.remove(filepath)
             except FileNotFoundError:
                 pass
+
 
 """
 Test that pytest uses the DTChecker for doctests

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -1,21 +1,29 @@
 import pytest
+import os
 from pathlib import PosixPath
 
 from . import module_cases, failure_cases, failure_cases_2, stopwords_cases
-
+from scpdt.plugin import copy_local_files
+from scpdt.tests.conftest import user_config
 
 pytest_plugins = ['pytester']
+
 
 """
 Test that pytest uses the DTChecker for doctests
 """
-"""
 def test_module_cases(pytester):
     path_str = module_cases.__file__
     python_file = PosixPath(path_str)
+    destination_dir = pytester.path
+    copied_files = copy_local_files(user_config.local_resources, destination_dir)
     result = pytester.inline_run(python_file, "--doctest-modules")
+    for filepath in copied_files:
+        try:
+            os.remove(filepath)
+        except FileNotFoundError:
+            pass
     assert result.ret == pytest.ExitCode.OK
-"""
 
 
 """ def test_failure_cases(pytester):

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -1,22 +1,20 @@
 import pytest
 import os
-from pathlib import PosixPath
+from pathlib import PosixPath, Path
 
-from . import module_cases, failure_cases, failure_cases_2, stopwords_cases
+from . import module_cases, failure_cases, failure_cases_2, stopwords_cases, local_file_cases
 from scpdt.plugin import copy_local_files
 from scpdt.tests.conftest import user_config
 
 pytest_plugins = ['pytester']
 
 
-"""
-Test that pytest uses the DTChecker for doctests
-"""
-
 @pytest.fixture(autouse=True)
 def copy_files():
-    dirname = os.path.dirname(os.getcwd())
-    copied_files = copy_local_files(user_config.local_resources, dirname)
+    dirname = os.path.dirname(Path(__file__))
+    for key, value in user_config.local_resources.items():
+        value[0] = os.path.join(dirname, os.path.basename(value[0]))
+    copied_files = copy_local_files(user_config.local_resources, os.getcwd())
     try: 
         yield copied_files
     finally:
@@ -26,6 +24,9 @@ def copy_files():
             except FileNotFoundError:
                 pass
 
+"""
+Test that pytest uses the DTChecker for doctests
+"""
 
 def test_module_cases(pytester):
     path_str = module_cases.__file__
@@ -48,6 +49,16 @@ Test that pytest uses the DTParser for doctests
 """
 def test_stopword_cases(pytester):
     path_str = stopwords_cases.__file__
+    python_file = PosixPath(path_str)
+    result = pytester.inline_run(python_file, "--doctest-modules")
+    assert result.ret == pytest.ExitCode.OK
+
+
+"""
+Test that local files are found for use in doctests
+"""
+def test_local_file_cases(pytester):
+    path_str = local_file_cases.__file__
     python_file = PosixPath(path_str)
     result = pytester.inline_run(python_file, "--doctest-modules")
     assert result.ret == pytest.ExitCode.OK

--- a/scpdt/tests/test_pytest_configuration.py
+++ b/scpdt/tests/test_pytest_configuration.py
@@ -1,10 +1,7 @@
 import pytest
 from pathlib import PosixPath
 
-
 from . import module_cases, failure_cases, failure_cases_2, stopwords_cases
-from scpdt.plugin import copy_local_files
-from scpdt.tests.conftest import user_config
 
 
 pytest_plugins = ['pytester']
@@ -12,12 +9,13 @@ pytest_plugins = ['pytester']
 """
 Test that pytest uses the DTChecker for doctests
 """
+"""
 def test_module_cases(pytester):
     path_str = module_cases.__file__
     python_file = PosixPath(path_str)
-    copy_local_files(user_config.local_resources)
     result = pytester.inline_run(python_file, "--doctest-modules")
     assert result.ret == pytest.ExitCode.OK
+"""
 
 
 """ def test_failure_cases(pytester):


### PR DESCRIPTION
- created a `DTConfig` object in `conftest.py` with `local_resources` specified that is passed to instances of `DTChecker`, `DTFinder` and `DTParser`
- created a `copy_local_files` function that ensures local files defined by config's `local_resources` attribute are copied to the cwd where pytest carries out its tests
- implemented the `pytest_unconfigure` hook to ensure all copied local files are deleted when testing is complete
- created a `copy_files` autouse fixture to ensure all local files are copied to the temporary directory used by `pytester` during self testing