### PR TITLE
Run tests in context managers

### DIFF
--- a/scpdt/conftest.py
+++ b/scpdt/conftest.py
@@ -9,3 +9,5 @@ dt_config.local_resources = {'scpdt.tests.local_file_cases.local_files':
                             'scpdt.tests.local_file_cases.sio':
                                   ['scpdt/tests/octave_a.mat']   
                                   }
+
+dt_config.nameerror_after_exception = True

--- a/scpdt/conftest.py
+++ b/scpdt/conftest.py
@@ -9,5 +9,3 @@ dt_config.local_resources = {'scpdt.tests.local_file_cases.local_files':
                             'scpdt.tests.local_file_cases.sio':
                                   ['scpdt/tests/octave_a.mat']   
                                   }
-
-dt_config.nameerror_after_exception = True

--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -318,7 +318,6 @@ class DTRunner(doctest.DocTestRunner):
     def __init__(self, checker=None, verbose=None, optionflags=None, config=None):
         if config is None:
             config = DTConfig()
-        self.config = config
         if checker is None:
             checker = DTChecker(config)
         self.nameerror_after_exception = config.nameerror_after_exception

--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -375,7 +375,7 @@ class DebugDTRunner(DTRunner):
     Almost verbatim copy of `doctest.DebugRunner`.
     """
     def run(self, test, compileflags=None, out=None, clear_globs=True):
-        r = super().run(test, compileflags=compileflags, out=out, clear_globs=False)
+        r = super().run(test, compileflags=compileflags, out=out, clear_globs=clear_globs)
         if clear_globs:
             test.globs.clear()
         return r

--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -6,7 +6,6 @@ from doctest import NORMALIZE_WHITESPACE, ELLIPSIS, IGNORE_EXCEPTION_DETAIL
 import numpy as np
 
 from . import util
-from .util import np_errstate, matplotlib_make_nongui
 
 # Register the optionflag to skip whole blocks, i.e.
 # sequences of Examples without an intervening text.
@@ -377,19 +376,10 @@ class DebugDTRunner(DTRunner):
     Almost verbatim copy of `doctest.DebugRunner`.
     """
     def run(self, test, compileflags=None, out=None, clear_globs=True):
-        """
-        Run tests in context managers:
-        np_errstate: restores the numpy errstate and printoptions when done
-        user_context_manager: allows user to plug in their own context manager
-        matplotlib_make_nongui: temporarily make the matplotlib backend non-GUI
-        """
-        with np_errstate():
-            with self.config.user_context_mgr(test):
-                with matplotlib_make_nongui():
-                    r = super().run(test, compileflags=compileflags, out=out, clear_globs=False)
-                    if clear_globs:
-                        test.globs.clear()
-                    return r
+        r = super().run(test, compileflags=compileflags, out=out, clear_globs=False)
+        if clear_globs:
+            test.globs.clear()
+        return r
 
     def report_unexpected_exception(self, out, test, example, exc_info):
         super().report_unexpected_exception(out, test, example, exc_info)

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -104,7 +104,7 @@ class DTModule(DoctestModule):
         finder = DTFinder(config=dt_config)
         optionflags = doctest.get_optionflags(self)
 
-        # We plugin scpdt's `DebugDTRunner`
+        # We plugin `PytestDTRunner`
         runner = _get_runner(
             verbose=False,
             optionflags=optionflags,
@@ -141,7 +141,7 @@ class DTTextfile(DoctestTextfile):
         if dt_config.local_resources:
             copy_local_files(dt_config.local_resources, os.getcwd())
 
-        # We plugin scpdt's `DebugDTRunner`
+        # We plugin `PytestDTRunner`
         runner = _get_runner(
             verbose=False,
             optionflags=optionflags,
@@ -170,19 +170,9 @@ def _get_parser():
 def _get_runner(checker, verbose, optionflags):
     import doctest
     """
-    Override function to return instance of DebugDTRunner
+    Override function to return instance of PytestDTRunner
     """
     class PytestDTRunner(DebugDTRunner):
-
-        def __init__(self, checker=None, verbose=None, optionflags=None, config=None, continue_on_failure=True):
-            super().__init__(checker=checker, verbose=verbose, optionflags=optionflags, config=config)
-            """
-            If `continue_on_failure is True, failures and exceptions are collected in the out stream. 
-            If it's False, the failure or exception is raised immediately, potentially stopping further 
-            execution of the particular doctest
-            """
-            self.continue_on_failure = continue_on_failure
-
         def run(self, test, compileflags=None, out=None, clear_globs=False):
             """
             Run tests in context managers:
@@ -200,7 +190,7 @@ def _get_runner(checker, verbose, optionflags):
         """
         def report_failure(self, out, test, example, got):
             failure = doctest.DocTestFailure(test, example, got)
-            if self.continue_on_failure:
+            if self.config.nameerror_after_exception:
                 out.append(failure)
             else:
                 raise failure
@@ -211,7 +201,7 @@ def _get_runner(checker, verbose, optionflags):
             if isinstance(exc_info[1], bdb.BdbQuit):
                 outcomes.exit("Quitting debugger")
             failure = doctest.UnexpectedException(test, example, exc_info)
-            if self.continue_on_failure:
+            if self.config.nameerror_after_exception:
                 out.append(failure)
             else:
                 raise failure


### PR DESCRIPTION
- plugged in the `DebugDTRunner`
- overrode its `run` function to ensure tests are run in context managers

Closes #82 