### PR TITLE
FIX: Move `local_resources` specification to module

### DIFF
--- a/scpdt/conftest.py
+++ b/scpdt/conftest.py
@@ -3,9 +3,3 @@ from scpdt.impl import DTConfig
 
 dt_config = DTConfig()
 
-# Specify local files required by doctests
-dt_config.local_resources = {'scpdt.tests.local_file_cases.local_files':
-                                  ['scpdt/tests/local_file.txt'],
-                            'scpdt.tests.local_file_cases.sio':
-                                  ['scpdt/tests/octave_a.mat']   
-                                  }

--- a/scpdt/tests/local_file_cases.py
+++ b/scpdt/tests/local_file_cases.py
@@ -1,3 +1,12 @@
+from scpdt.conftest import dt_config
+
+
+# Specify local files required by doctests
+dt_config.local_resources = {'scpdt.tests.local_file_cases.local_files':
+                                  ['scpdt/tests/local_file.txt'],
+                            'scpdt.tests.local_file_cases.sio':
+                                  ['scpdt/tests/octave_a.mat']   
+                                  }
 
 def local_files():
     """


### PR DESCRIPTION
Since the specification of the`local_resources` attribute is particular to the plugin's doctests, I moved it to the `local_files` module.
Now projects can use the `dt_config` instance with default configurations.