### PR TITLE
ENH: Generate doctest log

### DIFF
--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -16,7 +16,6 @@ from .util import np_errstate, matplotlib_make_nongui
 
 
 copied_files = []
-modules = []
 
 def pytest_configure(config):
     """
@@ -115,6 +114,7 @@ class DTModule(DoctestModule):
 
         for test in finder.find(module, module.__name__):
             if test.examples:  # skip empty doctests
+                # add name of module and function containing docstring example to the doctest log
                 generate_log(module, test)
                 yield doctest.DoctestItem.from_parent(
                     self, name=test.name, runner=runner, dtest=test
@@ -218,7 +218,13 @@ def _get_runner(checker, verbose, optionflags):
     return PytestDTRunner(checker=checker, verbose=verbose, optionflags=optionflags, config=dt_config)
 
 
+modules = []
+
 def generate_log(module, test):
+    """
+    Generate a list of modules and their functions whose
+    docstring examples have been doctested
+    """
     if test.examples:
         function_name = (test.name).split('.')[-1]
         with open('doctest.log', 'a') as LOGFILE:

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -16,6 +16,7 @@ from .util import np_errstate, matplotlib_make_nongui
 
 
 copied_files = []
+modules = []
 
 def pytest_configure(config):
     """
@@ -114,7 +115,6 @@ class DTModule(DoctestModule):
 
         for test in finder.find(module, module.__name__):
             if test.examples:  # skip empty doctests
-                # add name of module and function containing docstring example to the doctest log
                 generate_log(module, test)
                 yield doctest.DoctestItem.from_parent(
                     self, name=test.name, runner=runner, dtest=test
@@ -218,17 +218,11 @@ def _get_runner(checker, verbose, optionflags):
     return PytestDTRunner(checker=checker, verbose=verbose, optionflags=optionflags, config=dt_config)
 
 
-modules = []
-
 def generate_log(module, test):
-    """
-    Generate a list of modules and their functions whose
-    docstring examples have been doctested
-    """
     if test.examples:
         with open('doctest.log', 'a') as LOGFILE:
             if module.__name__ not in modules:
-                LOGFILE.write(module.__name__ + "\n")
+                LOGFILE.write("\n" + module.__name__ + "\n")
                 LOGFILE.write("="*len(module.__name__) + "\n")
                 modules.append(module.__name__)
             LOGFILE.write(test.name + "\n")

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -226,10 +226,9 @@ def generate_log(module, test):
     docstring examples have been doctested
     """
     if test.examples:
-        function_name = (test.name).split('.')[-1]
         with open('doctest.log', 'a') as LOGFILE:
             if module.__name__ not in modules:
                 LOGFILE.write(module.__name__ + "\n")
                 LOGFILE.write("="*len(module.__name__) + "\n")
                 modules.append(module.__name__)
-            LOGFILE.write(function_name + "\n")
+            LOGFILE.write(test.name + "\n")

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -16,6 +16,7 @@ from .util import np_errstate, matplotlib_make_nongui
 
 
 copied_files = []
+modules = []
 
 def pytest_configure(config):
     """
@@ -112,9 +113,9 @@ class DTModule(DoctestModule):
             checker=_get_checker()
         )
 
-        # the rest remains unchanged
         for test in finder.find(module, module.__name__):
             if test.examples:  # skip empty doctests
+                generate_log(module, test)
                 yield doctest.DoctestItem.from_parent(
                     self, name=test.name, runner=runner, dtest=test
                 )
@@ -215,3 +216,14 @@ def _get_runner(checker, verbose, optionflags):
                 raise failure
             
     return PytestDTRunner(checker=checker, verbose=verbose, optionflags=optionflags, config=dt_config)
+
+
+def generate_log(module, test):
+    if test.examples:
+        function_name = (test.name).split('.')[-1]
+        with open('doctest.log', 'a') as LOGFILE:
+            if module.__name__ not in modules:
+                LOGFILE.write(module.__name__ + "\n")
+                LOGFILE.write("="*len(module.__name__) + "\n")
+                modules.append(module.__name__)
+            LOGFILE.write(function_name + "\n")


### PR DESCRIPTION
- added a `generate_log` function to document functions whose doctest examples are executed

I installed this branch of scpdt to scipy to see what the log would look like. I have attached it below.

[doctest.log](https://github.com/ev-br/scpdt/files/12426885/doctest.log)
