### PR TITLE
ENH: Execute doctests in numpy unfuncs and compiled functions

### DIFF
--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from . import util
 
+
 # Register the optionflag to skip whole blocks, i.e.
 # sequences of Examples without an intervening text.
 SKIPBLOCK = doctest.register_optionflag('SKIPBLOCK')

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -42,6 +42,22 @@ def pytest_unconfigure(config):
             pass
 
 
+def pytest_ignore_collect(collection_path, config):
+    """
+    Ignore the tests directory and test modules
+    """
+    path_str = str(collection_path)
+    if "tests" in path_str or "test_" in path_str:
+        return True
+    
+
+def _get_checker():
+    """
+    Override function to return an instance of DTChecker
+    """
+    return DTChecker(config=dt_config)
+
+
 def copy_local_files(local_resources, destination_dir):
     """
     Copy necessary local files for doctests to the current working directory. 

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -65,13 +65,12 @@ def pytest_collection_modifyitems(config, items):
             # in case the preceding item is a function or a class
             obj_name = str(item).split('.')[-2]
             
-            
             # Extract the module name from the DocTest item
             dtest = item.dtest
             path = str(dtest).split(' ')[3].split(':')[0]
             dtest_module = os.path.basename(path)
             try:
-                 module = import_path(
+                module = import_path(
                     path,
                     root=config.rootpath,
                     mode=config.getoption("importmode"),
@@ -80,9 +79,8 @@ def pytest_collection_modifyitems(config, items):
                 module = None
 
             # Combine object name(if it exists), item name and module name to create a unique identifier
-            if module is not None and hasattr(module, obj_name) and callable(getattr(module, obj_name)):
-                unique_test_name = f"{obj_name}.{item_name}.{dtest_module}"
-
+            if module is not None  and obj_name != '__init__' and hasattr(module, obj_name) and callable(getattr(module, obj_name)):
+                unique_test_name = f"{dtest_module}.{obj_name}.{item_name}"
             else:
                 unique_test_name = f"{item_name}.{dtest_module}"
 
@@ -92,7 +90,6 @@ def pytest_collection_modifyitems(config, items):
 
         # Replace the original list of test items with the unique ones
         items[:] = unique_items
-
 
 
 def _get_checker():

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -169,7 +169,7 @@ class DTModule(DoctestModule):
         # The `_pytest.doctest` module uses the internal doctest parsing mechanism.
         # We plugin scpdt's `DTFinder` that uses the `DTParser` which parses the doctest examples 
         # from the python module or file and filters out stopwords and pseudocode.
-        finder = DTFinder(config=self.config.dt_config)
+        # finder = DTFinder(config=self.config.dt_config)
         optionflags = doctest.get_optionflags(self)
 
         # We plug in `PytestDTRunner`

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -46,9 +46,10 @@ def pytest_ignore_collect(collection_path, config):
     """
     Ignore the tests directory and test modules
     """
-    path_str = str(collection_path)
-    if "tests" in path_str or "test_" in path_str:
-        return True
+    if config.getoption("--doctest-modules"):
+        path_str = str(collection_path)
+        if "tests" in path_str or "test_" in path_str:
+            return True
     
 
 def _get_checker():

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -52,26 +52,27 @@ def pytest_ignore_collect(collection_path, config):
         
     
 def pytest_collection_modifyitems(config, items):
-    seen_test_names = set()
-    unique_items = []
+    if config.getoption("--doctest-modules"):
+        seen_test_names = set()
+        unique_items = []
 
-    for item in items:
-        item_name = str(item).split('.')[-1].strip('>')
-        
-        # Extract the module name from the DocTest item
-        dtest = item.dtest
-        path = str(dtest).split(' ')[3]
-        dtest_module = os.path.basename(path).split(':')[0]
+        for item in items:
+            item_name = str(item).split('.')[-1].strip('>')
+            
+            # Extract the module name from the DocTest item
+            dtest = item.dtest
+            path = str(dtest).split(' ')[3]
+            dtest_module = os.path.basename(path).split(':')[0]
 
-        # Combine item name and module name to create a unique identifier
-        unique_test_name = f"{item_name}.{dtest_module}"
+            # Combine item name and module name to create a unique identifier
+            unique_test_name = f"{item_name}.{dtest_module}"
 
-        if unique_test_name not in seen_test_names:
-            seen_test_names.add(unique_test_name)
-            unique_items.append(item)
+            if unique_test_name not in seen_test_names:
+                seen_test_names.add(unique_test_name)
+                unique_items.append(item)
 
-    # Replace the original list of test items with the unique ones
-    items[:] = unique_items
+        # Replace the original list of test items with the unique ones
+        items[:] = unique_items
 
 
 def _get_checker():

--- a/scpdt/tests/local_file_cases.py
+++ b/scpdt/tests/local_file_cases.py
@@ -8,6 +8,8 @@ dt_config.local_resources = {'scpdt.tests.local_file_cases.local_files':
                                   ['scpdt/tests/octave_a.mat']   
                                   }
 
+__all__ = ['local_files', 'sio']
+
 def local_files():
     """
     A doctest that tries to read a local file

--- a/scpdt/util.py
+++ b/scpdt/util.py
@@ -251,3 +251,4 @@ def get_public_objects(module, skiplist=None):
             continue
 
     return (items, names), failures
+


### PR DESCRIPTION
- used scpdt's `find_doctests` to discover doctests in public objects.