### PR TITLE
ENH: Specify public objects for doctesting

### DIFF
--- a/scpdt/tests/failure_cases.py
+++ b/scpdt/tests/failure_cases.py
@@ -1,3 +1,4 @@
+__all__ = ['func9', 'func10']
 
 def func9():
     """

--- a/scpdt/tests/failure_cases_2.py
+++ b/scpdt/tests/failure_cases_2.py
@@ -1,3 +1,5 @@
+__all__ = ['func_depr', 'func_name_error']
+
 def func_depr():
     """
     A test case for the user context mgr to turn warnings to errors.

--- a/scpdt/tests/module_cases.py
+++ b/scpdt/tests/module_cases.py
@@ -1,3 +1,5 @@
+__all__ = ['func', 'func2', 'func3', 'func4', 'func5', 'func6', 'func8', 'func7', 'manip_printoptions', 'array_abbreviation']
+
 def func():
     """
     >>> 2 / 3

--- a/scpdt/tests/stopwords_cases.py
+++ b/scpdt/tests/stopwords_cases.py
@@ -1,3 +1,5 @@
+__all__ = ['func8']
+
 def func8():
     """Handle MPL stopwords.
     >>> import matplotlib.pyplot as plt

--- a/scpdt/tests/test_finder.py
+++ b/scpdt/tests/test_finder.py
@@ -16,7 +16,7 @@ def test_get_all_list_no_all():
     try:
         del finder_cases.__all__
         items, depr, other = get_all_list(finder_cases)
-        assert sorted(items) == ['Klass', 'func', 'private_func']
+        assert items == []
     finally:
         from importlib import reload
         reload(finder_cases)

--- a/scpdt/util.py
+++ b/scpdt/util.py
@@ -168,17 +168,15 @@ def is_deprecated(f):
 
 def get_all_list(module):
     """Return a copy of the __all__ list with irrelevant items removed.
-
-    - If __all__ is missing, process the output of `dir(module)`.
+    The __all__list explicitly specifies which objects should be considered public.
+    - If strategy="api" and __all__ is missing, return an empty list.
     - Also return a list of deprecated items and "other" items, which failed
       to classify.
     """
     if hasattr(module, "__all__"):
         all_list = copy.deepcopy(module.__all__)
     else:
-        all_list = copy.deepcopy(dir(module))
-        all_list = [name for name in all_list
-                    if not name.startswith("_")]
+        all_list = []
     for name in ['absolute_import', 'division', 'print_function']:
         try:
             all_list.remove(name)


### PR DESCRIPTION
- if `strategy=api`, only public objects specified in an `__all__` attribute within the module should be collected for doctesting.

Closes #98