### PR TITLE
Refactor `pytest_collection_modify` hook

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -52,6 +52,14 @@ jobs:
       run: |
         python -m scpdt scpdt/tests/finder_cases.py -vv
 
+    - name: Test pytest plugin
+      # This test will fail in a venv where scpdt has not been installed and the plugin has not been activated
+      run: |
+        test_files=("scpdt/tests/module_cases.py" "scpdt/tests/stopwords_cases.py" "scpdt/tests/local_file_cases.py")
+          for file in "${test_files[@]}"; do
+            python -m pytest "${file}" --doctest-modules
+          done
+
     - name: Test testfile CLI
       run: |
         python -m scpdt ./scpdt/tests/scipy_linalg_tutorial_clone.rst -v
@@ -65,10 +73,3 @@ jobs:
         python -mpip install pooch
         python -c'from scipy import ndimage; from scpdt import testmod; testmod(ndimage, verbose=True, strategy="api")'
 
-    - name: Test pytest plugin
-      # This test will fail in a venv where scpdt has not been installed and the plugin has not been activated
-      run: |
-        test_files=("scpdt/tests/module_cases.py" "scpdt/tests/stopwords_cases.py" "scpdt/tests/local_file_cases.py")
-          for file in "${test_files[@]}"; do
-            python -m pytest "${file}" --doctest-modules
-          done

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -52,14 +52,6 @@ jobs:
       run: |
         python -m scpdt scpdt/tests/finder_cases.py -vv
 
-    - name: Test pytest plugin
-      # This test will fail in a venv where scpdt has not been installed and the plugin has not been activated
-      run: |
-        test_files=("scpdt/tests/module_cases.py" "scpdt/tests/stopwords_cases.py" "scpdt/tests/local_file_cases.py")
-          for file in "${test_files[@]}"; do
-            python -m pytest "${file}" --doctest-modules
-          done
-
     - name: Test testfile CLI
       run: |
         python -m scpdt ./scpdt/tests/scipy_linalg_tutorial_clone.rst -v
@@ -73,3 +65,10 @@ jobs:
         python -mpip install pooch
         python -c'from scipy import ndimage; from scpdt import testmod; testmod(ndimage, verbose=True, strategy="api")'
 
+    - name: Test pytest plugin
+      # This test will fail in a venv where scpdt has not been installed and the plugin has not been activated
+      run: |
+        test_files=("scpdt/tests/module_cases.py" "scpdt/tests/stopwords_cases.py" "scpdt/tests/local_file_cases.py")
+          for file in "${test_files[@]}"; do
+            python -m pytest "${file}" --doctest-modules
+          done

--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -68,6 +68,9 @@ class DTConfig:
         NameErrors. Set to True if you want to see these, or if your test
         is actually expected to raise NameErrors.
         Default is False.
+    pytest_extra_skips : list
+        A list of names/modules to skip when run under pytest plugin. Ignored
+        otherwise.
 
     """
     def __init__(self, *, # DTChecker configuration
@@ -88,6 +91,7 @@ class DTConfig:
                           # Obscure switches
                           parse_namedtuples=True,  # Checker
                           nameerror_after_exception=False,  # Runner
+                          pytest_extra_skips=None,        # plugin/collection
     ):
         ### DTChecker configuration ###
         # The namespace to run examples in
@@ -170,6 +174,11 @@ class DTConfig:
         #### Obscure switches, best leave intact
         self.parse_namedtuples = parse_namedtuples
         self.nameerror_after_exception = nameerror_after_exception
+
+        #### pytest plugin additional switches
+        if pytest_extra_skips is None:
+            pytest_extra_skips = []
+        self.pytest_extra_skips = pytest_extra_skips
 
 
 def try_convert_namedtuple(got):

--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -141,7 +141,8 @@ class DTConfig:
                  'set_title', 'imshow', 'plt.show', '.axis(', '.plot(',
                  '.bar(', '.title', '.ylabel', '.xlabel', 'set_ylim', 'set_xlim',
                  '# reformatted', '.set_xlabel(', '.set_ylabel(', '.set_zlabel(',
-                 '.set(xlim=', '.set(ylim=', '.set(xlabel=', '.set(ylabel=', '.xlim('}
+                 '.set(xlim=', '.set(ylim=', '.set(xlabel=', '.set(ylabel=', '.xlim('
+                 'ax.set('}
         self.stopwords = stopwords
 
         if pseudocode is None:


### PR DESCRIPTION
Refactor the doctest collection stage a bit. 

The key simplifications are
   - for dev installs, only run pytest on the `build-install` folder. Its contents matches the installed version, so it should be identical to `$ pytest --pyargs scipy` for an installed scipy (I think?). This obviates the need for the `PY_IGNORE_IMPORTMISMATCH=1` env var --- almost. The remaining need seems to be due to some weirdness in `scipy.signal`, which indeed has a matching `.py` and `.so` modules:

```
E   _pytest.pathlib.ImportPathMismatchError: ('scipy.signal._spectral', '/home/br/repos/scipy/scipy/build-install/lib/python3.10/site-packages/scipy/signal/_spectral.cpython-310-x86_64-linux-gnu.so', PosixPath('/home/br/repos/scipy/scipy/build-install/lib/python3.10/site-packages/scipy/signal/_spectral.py'))
```
This probably needs to be looked at on the scipy side.

  - The logfile generation can be done with `pytest --collect-only ...` and some light postprocessing (below the fold)

The full stanza to run this, including pytest ignores, is currently (I know)

```
$ python dev.py shell
$ cd ~/repos/scipy/scipy
$ PY_IGNORE_IMPORTMISMATCH=1 pytest build-install/lib/python3.10/site-packages/scipy/ --doctest-modules --ignore=build-install/lib/python3.10/site-packages/scipy/interpolate/_interpnd_info.py --ignore=build-install/lib/python3.10/site-packages/scipy/_lib --collect-only
```

Log posprocessing scripts are below the fold:
<details>

```
$ cat modify_log.py

# convert the result of 
# $ pytest ... --doctest-modules --collect-only
# to simplify comparing to the doctest_.log from doctest-based runs

PACKAGE = "scipy."

if __name__ == "__main__":
    import sys
    if len(sys.argv) != 2:
        print("Usage: modify_log.py LOGFILE")

    fname = sys.argv[1]
    with open(fname, 'r') as inf:
        in_lines = inf.readlines()

    out_lines = []
    for line in in_lines:
        line_ = line.strip()
         
        if line_.startswith("<DoctestItem"):
            out_lines.append(line_[13:-1])

    print("\n".join(sorted(out_lines)))
```
and 

```
$ cat modify_doctest_log.py 
# strip module names from the doctest.log
# to simplify comparing to the doctest_.log from doctest-based runs

PACKAGE = "scipy."

if __name__ == "__main__":
    import sys
    if len(sys.argv) != 2:
        print("Usage: modify_log.py LOGFILE")

    fname = sys.argv[1]
    with open(fname, 'r') as inf:
        in_lines = inf.readlines()

    out_lines = []
    for j, line in enumerate(in_lines):
        line_ = line.strip()

        if line_.startswith("="):
            continue

        if j < len(in_lines) -1 and in_lines[j+1].startswith("="):
            continue

        out_lines.append(line_)

    print("\n".join(sorted(out_lines)))
```
</details>

With these, the logs agree for the following combination: https://github.com/ev-br/scipy/tree/doctest_plugin + this PR, and https://github.com/scipy/scipy/pull/16391, modulo https://github.com/ev-br/scpdt/issues/106. 

