### PR TITLE
BUG: plugin: get optionflags from DTConfig

### DIFF
--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -168,7 +168,7 @@ class DTModule(DoctestModule):
         if self.config.dt_config.local_resources:
             copy_local_files(self.config.dt_config.local_resources, os.getcwd())
 
-        optionflags = doctest.get_optionflags(self)
+        optionflags = dt_config.optionflags
 
         # Plug in the custom runner: `PytestDTRunner` 
         runner = _get_runner(self.config,


### PR DESCRIPTION
With this, checking scipy using the recipe from https://github.com/ev-br/scpdt/pull/107 seems to work. This obviates the need for several whitespace fixes from https://github.com/scipy/scipy/pull/19242.

(split off gh-111)