### PR TITLE
MAINT: remove generate_log; can use `pytest --doctest-modules --collect-only`

### DIFF
--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -13,7 +13,7 @@ from _pytest.outcomes import skip, OutcomeException
 
 from scpdt.impl import DTChecker, DTParser, DebugDTRunner
 from scpdt.conftest import dt_config
-from .util import np_errstate, matplotlib_make_nongui, generate_log
+from .util import np_errstate, matplotlib_make_nongui
 from scpdt.frontend import find_doctests
 
 

--- a/scpdt/util.py
+++ b/scpdt/util.py
@@ -251,6 +251,7 @@ def get_public_objects(module, skiplist=None):
     return (items, names), failures
 
 
+# XXX: not used ATM
 modules = []
 def generate_log(module, test):
     """


### PR DESCRIPTION
For collection coverage, can use `pytest --doctest-modules --collect-only`,
see https://github.com/ev-br/scpdt/wiki/Compare-the-coverage for details.

closes gh-97