### PR TITLE
CI: add a workflow with pytest == 8

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ['3.10']
         os:  [ubuntu-latest]
-        pytest: ['"pytest<8.0"']
+        pytest: ['"pytest<8.0"', pytest]
         # pip cache paths
         include:
         - os: ubuntu-latest

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11']
         os:  [ubuntu-latest]
         pytest: ['"pytest<8.0"', pytest]
         # pip cache paths


### PR DESCRIPTION
closes gh-108 --- that issue was a fluke, apparently? Or one of refactorings fixed it.