### PR TITLE
Skip empty doctests, stop blank filtering DeprecationWarnings

### DIFF
--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -259,10 +259,7 @@ def _get_runner(config, checker, verbose, optionflags):
             with np_errstate():
                 with config.dt_config.user_context_mgr(test):
                     with matplotlib_make_nongui():
-                        # XXX: might want to add the filter to `testmod`, too
-                        with warnings.catch_warnings():
-                            warnings.filterwarnings("ignore", category=DeprecationWarning)
-                            super().run(test, compileflags=compileflags, out=out, clear_globs=clear_globs)
+                        super().run(test, compileflags=compileflags, out=out, clear_globs=clear_globs)
 
         """
         Almost verbatim copy of `_pytest.doctest.PytestDoctestRunner` except we utilize

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -181,7 +181,7 @@ class DTModule(DoctestModule):
             # We utilize scpdt's `find_doctests` function to discover doctests in public, non-deprecated objects in the module
             # NB: additional postprocessing in pytest_collection_modifyitems
             for test in find_doctests(module, strategy="api", name=module.__name__, config=dt_config):
-#                if test.examples: # skip empty doctests  # FIXME: put this back (simplifies comparing the logs)
+                if test.examples: # skip empty doctests
                     yield doctest.DoctestItem.from_parent(
                         self, name=test.name, runner=runner, dtest=test
                     )


### PR DESCRIPTION
- Put back the skip of docstrings with no doctest examples: pytest does it, and there is no reason not to. If we don't skip them here, `pytest --doctest-modules` reports them as if they had `+SKIP` anyway.
- Stop filtering all DeprecationWarnings. This was a temp filter IIUC, and this is bad practice in general. Either rewrite the docstring to avoid deprecated stuff, or use a more granular filter in `dt_context.user_context_mgr`.