### PR TITLE
BUG: fix testing *rst tutorials

### DIFF
--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -41,6 +41,10 @@ def pytest_ignore_collect(collection_path, config):
         if "tests" in path_str or "test_" in path_str:
             return True
 
+    for entry in config.dt_config.pytest_extra_skips:
+        if entry in str(collection_path):
+            return True
+
 
 def pytest_collection_modifyitems(config, items):
     """
@@ -81,7 +85,7 @@ def pytest_collection_modifyitems(config, items):
 
             parent_full_name = item.parent.module.__name__
             is_public = "._" not in parent_full_name
-            is_duplicate = parent_full_name in  extra_skips or item.name in extra_skips
+            is_duplicate = parent_full_name in extra_skips or item.name in extra_skips
 
             if is_public and not is_duplicate:
                 unique_items.append(item)
@@ -160,7 +164,7 @@ class DTTextfile(DoctestTextfile):
         name = self.path.name
         globs = {"__name__": "__main__"}
 
-        optionflags = pydoctest.get_optionflags(self)
+        optionflags = dt_config.optionflags
 
         # Plug in the custom runner: `PytestDTRunner`
         runner = _get_runner(self.config,
@@ -205,7 +209,6 @@ def _get_runner(config, checker, verbose, optionflags):
             *before* they become errors in `config.user_context_mgr()`.
             """
             dt_config = config.dt_config
-
 
             with np_errstate():
                 with dt_config.user_context_mgr(test):


### PR DESCRIPTION
- get optionflags from DTConfig
- allow pytest_extra_skips in collection

This is a minimal fix to close #130:  the following passes on scipy

```
$ python dev.py shell
$ cd scipy/doc/source/tutorials
$ pytest doc/source/tutorial/ --doctest-glob=*rst
```

Further enhancements are tracked in #132, #56.

Further UX improvements:
- why is `--doctest-glob=*rst` needed? Looks like there's an issue in https://github.com/pytest-dev/pytest/blob/8.0.2/src/_pytest/doctest.py#L138 and https://github.com/pytest-dev/pytest/blob/8.0.2/src/_pytest/doctest.py#L151 --- figure out or report upstream?
- cook up a nicer UX for `dev.py`: with refguide-check it was "skip tutorials if -s submodule, run them otherwise". Not nice.
