### PR TITLE
MAINT: a nicer way to detect a module is deprecated in DTModule

### DIFF
--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -114,6 +114,22 @@ def pytest_collection_modifyitems(config, items):
         items[:] = unique_items
 
 
+def _is_deprecated(module):
+    """Detect if a module is deprecated (i.e., raises or warns on getattr)."""
+    names = dir(module)
+    if not names:
+        return False
+
+    res = False
+    try:
+        getattr(module, names[0])
+        res = False
+    except DeprecationWarning:
+        res = True
+
+    return res
+
+
 class DTModule(DoctestModule):
     """
     This class extends the DoctestModule class provided by pytest.
@@ -146,6 +162,10 @@ class DTModule(DoctestModule):
                 else:
                     raise
 
+        if _is_deprecated(module):
+            # bail out early
+            return
+
         optionflags = dt_config.optionflags
 
         # Plug in the custom runner: `PytestDTRunner` 
@@ -161,15 +181,12 @@ class DTModule(DoctestModule):
         if strategy == 'None':
             strategy = None
 
-        try:
-            # NB: additional postprocessing in pytest_collection_modifyitems
-            for test in find_doctests(module, strategy=strategy, name=module.__name__, config=dt_config):
-                if test.examples: # skip empty doctests
-                    yield pydoctest.DoctestItem.from_parent(
-                        self, name=test.name, runner=runner, dtest=test
-                    )
-        except:
-            pass
+        # NB: additional postprocessing in pytest_collection_modifyitems
+        for test in find_doctests(module, strategy=strategy, name=module.__name__, config=dt_config):
+            if test.examples: # skip empty doctests
+                yield pydoctest.DoctestItem.from_parent(
+                    self, name=test.name, runner=runner, dtest=test
+                )
         
 
 class DTTextfile(DoctestTextfile):


### PR DESCRIPTION
The `try-except-pass` stanza was bothering me every time I saw it. 

Turns out it was to filter out modules which are deprecated, meaning they emit a DeprecationWarning on an attribute access. Consider

```
In [1]: from scipy.constants import constants      # deprecated submodule constants.constants

In [2]: constants.zetta      # DeprecationWarning
<ipython-input-5-835b60441caf>:1: DeprecationWarning: Please import `zetta` from the `scipy.constants` namespace; the `scipy.constants.constants` namespace is deprecated and will be removed in SciPy 2.0.0.
  constants.zetta
Out[5]: 1e+21
```

Note however that non-existent attributes still raise an AttributeError, only with a helpful error message:

```
In [3]: constants.tapas                 # non-existent attr: AttributeError w/ special error message
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 constants.tapas

File ~/repos/scipy/scipy/build-install/lib/python3.10/site-packages/scipy/constants/constants.py:51, in __getattr__(name)
     50 def __getattr__(name):
---> 51     return _sub_module_deprecation(sub_package="constants", module="constants",
     52                                    private_modules=["_constants"], all=__all__,
     53                                    attribute=name)

File ~/repos/scipy/scipy/build-install/lib/python3.10/site-packages/scipy/_lib/deprecation.py:42, in _sub_module_deprecation(sub_package, module, private_modules, all, attribute, correct_module)
     39     correct_import = f"scipy.{sub_package}"
     41 if attribute not in all:
---> 42     raise AttributeError(
     43         f"`scipy.{sub_package}.{module}` has no attribute `{attribute}`; "
     44         f"furthermore, `scipy.{sub_package}.{module}` is deprecated "
     45         f"and will be removed in SciPy 2.0.0."
     46     )
     48 attr = getattr(import_module(correct_import), attribute, None)
     50 if attr is not None:

AttributeError: `scipy.constants.constants` has no attribute `tapas`; furthermore, `scipy.constants.constants` is deprecated and will be removed in SciPy 2.0.0.
```