### PR TITLE
BUG: more robust filter DeprecationWarnings

### DIFF
--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -163,8 +163,10 @@ def _is_deprecated(module):
 
     res = False
     try:
-        getattr(module, names[0])
-        res = False
+        with warnings.catch_warnings() as w:
+            warnings.simplefilter('error', DeprecationWarning)
+            getattr(module, names[0])
+            res = False
     except DeprecationWarning:
         res = True
 


### PR DESCRIPTION
With this, running

```
$ pytest --pyargs scipy --doctest-modules --ignore=/home/br/repos/scipy/scipy/build-install/lib/python3.10/site-packages/scipy/_lib --ignore=../../repos/scipy/scipy/build-install/lib/python3.10/site-packages/scipy/interpolate/_interpnd_info.py --doctest-collect=api -x ================================= test session starts ================================== platform linux -- Python 3.10.10, pytest-8.0.1, pluggy-1.3.0 rootdir: /home/br/sweethome/temp
plugins: scpdt-0.1, anyio-4.2.0, cov-4.0.0, timeout-2.1.0, hypothesis-6.84.3, xdist-3.2.1 collected 2497 items

cluster/hierarchy.py ...............................                             [  2%]
cluster/vq.py ....                                                               [  2%]
constants/__init__.py ...............                                            [  3%]
datasets/__init__.py ....                                                        [  4%]
fft/__init__.py .................................                                [  6%]
fftpack/__init__.py ................                                             [  7%]
integrate/__init__.py .................                                          [  9%]
interpolate/__init__.py ..................................................       [ 13%]
io/__init__.py ...........                                                       [ 13%]
io/arff/__init__.py .                                                            [ 13%]
io/matlab/__init__.py ...                                                        [ 14%]
io/wavfile.py ..                                                                 [ 14%]
linalg/__init__.py ............................................................. [ 19%]
....................................                                             [ 21%]
linalg/blas.py ..                                                                [ 21%]
linalg/interpolative.py .                                                        [ 22%]
linalg/lapack.py .                                                               [ 22%]
ndimage/__init__.py ............................................................ [ 26%]
.......                                                                          [ 27%]
odr/__init__.py .....                                                            [ 27%]
optimize/__init__.py .....................................................       [ 31%]
signal/__init__.py ............................................................. [ 36%]
............................................................................     [ 42%]
signal/windows/__init__.py ..........................                            [ 44%]
sparse/__init__.py ..........................................                    [ 47%]
sparse/csgraph/__init__.py .........................                             [ 49%]
sparse/linalg/__init__.py ...............................                        [ 51%]
spatial/__init__.py ..........................                                   [ 53%]
spatial/distance.py .............................                                [ 55%]
spatial/transform/__init__.py ..........................                         [ 57%]
special/__init__.py ............................................................ [ 62%]
................................................................................ [ 68%]
.....................................................................            [ 73%]
stats/__init__.py .............................................................. [ 78%]
................................................................................ [ 84%]
................................................................................ [ 91%]
..............................................................                   [ 95%]
stats/contingency.py .......                                                     [ 96%]
stats/mstats.py ..........................                                       [ 98%]
stats/qmc.py ...........                                                         [ 99%]
stats/sampling.py ...........                                                    [100%]

=========================== 1303 passed in 203.44s (0:03:23) ===========================
```
succeeds and the number of doctests is the same as for the dev install.

closes gh-137.