### PR TITLE
ENH: make OutputChecker pluggable

### DIFF
--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -85,6 +85,7 @@ class DTConfig:
         a string. If not empty, the string value is used as the skip reason.
     """
     def __init__(self, *, # DTChecker configuration
+                          CheckerKlass=None,
                           default_namespace=None,
                           check_namespace=None,
                           rndm_markers=None,
@@ -108,6 +109,8 @@ class DTConfig:
                           pytest_extra_xfail=None,
     ):
         ### DTChecker configuration ###
+        self.CheckerKlass = CheckerKlass or DTChecker
+
         # The namespace to run examples in
         self.default_namespace = default_namespace or {}
 
@@ -340,7 +343,7 @@ class DTRunner(doctest.DocTestRunner):
         if config is None:
             config = DTConfig()
         if checker is None:
-            checker = DTChecker(config)
+            checker = config.CheckerKlass(config)
         self.nameerror_after_exception = config.nameerror_after_exception
         if optionflags is None:
             optionflags = config.optionflags

--- a/scpdt/plugin.py
+++ b/scpdt/plugin.py
@@ -213,7 +213,6 @@ class DTModule(DoctestModule):
         runner = _get_runner(self.config,
             verbose=False,
             optionflags=optionflags,
-            checker=DTChecker(config=self.config.dt_config)
         )
 
         # strategy='api': discover doctests in public, non-deprecated objects in module
@@ -228,7 +227,7 @@ class DTModule(DoctestModule):
                 yield pydoctest.DoctestItem.from_parent(
                     self, name=test.name, runner=runner, dtest=test
                 )
-        
+
 
 class DTTextfile(DoctestTextfile):
     """
@@ -253,7 +252,6 @@ class DTTextfile(DoctestTextfile):
         runner = _get_runner(self.config,
             verbose=False,
             optionflags=optionflags,
-            checker=DTChecker(config=self.config.dt_config)
         )
 
         # Plug in an instance of `DTParser` which parses the doctest examples from the text file and
@@ -268,7 +266,7 @@ class DTTextfile(DoctestTextfile):
             )
 
 
-def _get_runner(config, checker, verbose, optionflags):
+def _get_runner(config, verbose, optionflags):
     """
     Override function to return an instance of PytestDTRunner.
     
@@ -321,5 +319,5 @@ def _get_runner(config, checker, verbose, optionflags):
                 out.append(failure)
             else:
                 raise failure
-            
-    return PytestDTRunner(checker=checker, verbose=verbose, optionflags=optionflags, config=config.dt_config)
+
+    return PytestDTRunner(verbose=verbose, optionflags=optionflags, config=config.dt_config)


### PR DESCRIPTION
Add CheckerKlass attribute to DTConfig for the class name of the Checker, use in instantiating the Runner. Then it percolates all the way up to all sorts of frontends, both doctest and pytest layers.

DTConfig gets a bit crowded, and it becomes easy to silently ignore some keys: VanillaOutputChecker ignores atol/rtol etc. If this ever becomes a problem, can add more structure to DTConfig. 
The right thing is likely to make DTConfig hold actual objects not classes and their instantiation parameters.
That would be a larger change though, so let's get there when it gets more usage.
Until then, let's keep it simple. 

cross-ref gh-38.
