### PR TITLE
MAINT: close the figures before backend change

### DIFF
--- a/scpdt/util.py
+++ b/scpdt/util.py
@@ -17,7 +17,9 @@ def matplotlib_make_nongui():
     """
     try:
         import matplotlib
+        import matplotlib.pyplot as plt
         backend = matplotlib.get_backend()
+        plt.close('all')
         matplotlib.use('Agg')
     except ImportError:
         backend = None


### PR DESCRIPTION
MPL 3.8 issues a DeprecationWarning, follow its suggestion:


scpdt/tests/test_testfile.py::test_one_scipy_tutorial
Auto-close()ing of figures upon backend switching is deprecated since 3.8 and will be removed two minor releases later.  To suppress this warning, explicitly call plt.close('all') first.
    matplotlib.use('Agg')


Found while looking at gh-131