### PR TITLE
MAINT: Adapt to NumPy 2.0

### DIFF
--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -8,6 +8,13 @@ import numpy as np
 from . import util
 
 
+## shim numpy 1.x vs 2.0
+if np.__version__ < "2":
+    VisibleDeprecationWarning = np.VisibleDeprecationWarning
+else:
+    VisibleDeprecationWarning = np.exceptions.VisibleDeprecationWarning
+
+
 # Register the optionflag to skip whole blocks, i.e.
 # sequences of Examples without an intervening text.
 SKIPBLOCK = doctest.register_optionflag('SKIPBLOCK')
@@ -254,7 +261,7 @@ class DTChecker(doctest.OutputChecker):
             with warnings.catch_warnings():
                 # NumPy's ragged array deprecation of np.array([1, (2, 3)]);
                 # also array abbreviations: try `np.diag(np.arange(1000))`
-                warnings.simplefilter('ignore', np.VisibleDeprecationWarning)
+                warnings.simplefilter('ignore', VisibleDeprecationWarning)
 
                 a_want = eval(want, dict(ns))
                 a_got = eval(got, dict(ns))
@@ -329,7 +336,7 @@ class DTChecker(doctest.OutputChecker):
             pass
         with warnings.catch_warnings():
             # NumPy's ragged array deprecation of np.array([1, (2, 3)])
-            warnings.simplefilter('ignore', np.VisibleDeprecationWarning)
+            warnings.simplefilter('ignore', VisibleDeprecationWarning)
 
             # This line is the crux of the whole thing. The rest is mostly scaffolding.
             result = np.allclose(want, got, atol=self.atol, rtol=self.rtol)

--- a/scpdt/util.py
+++ b/scpdt/util.py
@@ -27,8 +27,9 @@ def matplotlib_make_nongui():
     try:
         # Matplotlib issues UserWarnings on plt.show() with a non-GUI backend,
         # Filter them out.
+        # UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "Matplotlib", UserWarning)
+            warnings.filterwarnings("ignore", "FigureCanvasAgg", UserWarning)
             yield backend
     finally:
         if backend:


### PR DESCRIPTION
Otherwise self-tests simply hang: np.VisibleDeprecatinWarning is not found at https://github.com/ev-br/scpdt/blob/main/scpdt/impl.py#L254, so we get into the `except Exception:` branch and it all goes downhill from there.

cross-ref https://github.com/ev-br/scpdt/issues/79#issuecomment-1963747649