### PR TITLE
ENH: treat nans as equal

### DIFF
--- a/scpdt/impl.py
+++ b/scpdt/impl.py
@@ -139,6 +139,8 @@ class DTConfig:
                   'float64': np.float64,
                   'dtype': np.dtype,
                   'nan': np.nan,
+                  'nanj': np.complex128(1j*np.nan),
+                  'infj': complex(0, np.inf),
                   'NaN': np.nan,
                   'inf': np.inf,
                   'Inf': np.inf, }
@@ -343,7 +345,7 @@ class DTChecker(doctest.OutputChecker):
             warnings.simplefilter('ignore', VisibleDeprecationWarning)
 
             # This line is the crux of the whole thing. The rest is mostly scaffolding.
-            result = np.allclose(want, got, atol=self.atol, rtol=self.rtol)
+            result = np.allclose(want, got, atol=self.atol, rtol=self.rtol, equal_nan=True)
         return result
 
 

--- a/scpdt/tests/module_cases.py
+++ b/scpdt/tests/module_cases.py
@@ -163,3 +163,24 @@ def array_abbreviation():
            [0,    0,    0, ...,    0,  999,    0],
            [0,    0,    0, ...,    0,    0, 1000]])
     """
+
+def nan_equal():
+    """
+    Test that nans are treated as equal.
+
+    >>> import numpy as np
+    >>> np.nan
+    np.float64(nan)
+
+    Complex nans
+    >>> np.nan - 1j*np.nan
+    nan + nanj
+
+    >>> np.nan + 1j*np.nan
+    np.complex128(nan+nanj)
+
+    Throw in infs, for a good measure
+    >>> np.inf + 1j*np.inf
+    inf + infj
+
+    """


### PR DESCRIPTION
closes gh-150

(now that I finally RTFM, `allclose` does have an `equal_nan=True` switch).

While at it, handle complex nans and infs.