### PR TITLE
ENH: Remove <BLANKLINE> tags before evaluating

### DIFF
--- a/scipy_doctest/impl.py
+++ b/scipy_doctest/impl.py
@@ -357,7 +357,7 @@ class DTChecker(doctest.OutputChecker):
         ns = dict(self.config.check_namespace)
         try:
             a_want = eval(want.replace("<BLANKLINE>", ""), dict(ns))
-            a_got = eval(got.replace("<BLANKLINE>", ""), dict(ns))
+            a_got = eval(got, dict(ns))
         except Exception:
             # Maybe we're printing a numpy array? This produces invalid python
             # code: `print(np.arange(3))` produces "[0 1 2]" w/o commas between

--- a/scipy_doctest/impl.py
+++ b/scipy_doctest/impl.py
@@ -356,8 +356,8 @@ class DTChecker(doctest.OutputChecker):
         # OK then, convert strings to objects
         ns = dict(self.config.check_namespace)
         try:
-            a_want = eval(want, dict(ns))
-            a_got = eval(got, dict(ns))
+            a_want = eval(want.replace("<BLANKLINE>", ""), dict(ns))
+            a_got = eval(got.replace("<BLANKLINE>", ""), dict(ns))
         except Exception:
             # Maybe we're printing a numpy array? This produces invalid python
             # code: `print(np.arange(3))` produces "[0 1 2]" w/o commas between

--- a/scipy_doctest/tests/module_cases.py
+++ b/scipy_doctest/tests/module_cases.py
@@ -274,6 +274,7 @@ def list_of_tuples_numeric():
 def rank_3_array_repr():
     """Check recovery of rank-3 array from doctest-style repr.
 
+    >>> import numpy as np
     >>> np.arange(24).reshape(2, 3, 4)
     array([[[ 0,  1,  2,  3],
             [ 4,  5,  6,  7],

--- a/scipy_doctest/tests/module_cases.py
+++ b/scipy_doctest/tests/module_cases.py
@@ -271,6 +271,20 @@ def list_of_tuples_numeric():
     """
 
 
+def rank_3_array_repr():
+    """Check recovery of rank-3 array from doctest-style repr.
+
+    >>> np.arange(24).reshape(2, 3, 4)
+    array([[[ 0,  1,  2,  3],
+            [ 4,  5,  6,  7],
+            [ 8,  9, 10, 11]],
+    <BLANKLINE>
+           [[12, 13, 14, 15],
+            [16, 17, 18, 19],
+            [20, 21, 22, 23]]])
+    """
+
+
 # This is used by test_testmod.py::test_public_object_discovery
 # While in test we only need __all__ to be not empty, let's make it correct, too.
 __all__ = [x for x in vars().keys() if not x.startswith("_")]


### PR DESCRIPTION
Doctest stops collecting output on a blank line: if the expected output includes a blank line, that is indicated with a `<BLANKLINE>` tag.  That tag is not valid python, so it needs to be removed before evaluating output for np.isclose.

Needs tests, though I'm not sure where to put them.  The following should work:
```pycon
>>> np.arange(24).reshape(2, 3, 4)
array([[[ 0,  1,  2,  3],
        [ 4,  5,  6,  7],
        [ 8,  9, 10, 11]],
<BLANKLINE>
       [[12, 13, 14, 15],
        [16, 17, 18, 19],
        [20, 21, 22, 23]]])
```

I did check that this stops flagging the $10^{-15}$ differences in scipy/scipy#23951 as failures.